### PR TITLE
feat: 공통 exception 위한 클래스 추가한다.

### DIFF
--- a/src/main/java/life/offonoff/ab/exception/AbCode.java
+++ b/src/main/java/life/offonoff/ab/exception/AbCode.java
@@ -1,0 +1,8 @@
+package life.offonoff.ab.exception;
+
+public enum AbCode {
+    INVALID_FIELD,
+    CATEGORY_NOT_FOUND,
+    INVALID_LENGTH_OF_FIELD
+    ;
+}

--- a/src/main/java/life/offonoff/ab/exception/AbException.java
+++ b/src/main/java/life/offonoff/ab/exception/AbException.java
@@ -1,0 +1,11 @@
+package life.offonoff.ab.exception;
+
+public abstract class AbException extends RuntimeException {
+    public AbException(String message) {
+        super(message);
+    }
+
+    public abstract String getHint();
+    public abstract int getHttpStatusCode();
+    public abstract AbCode getAbCode();
+}

--- a/src/main/java/life/offonoff/ab/exception/CategoryNotFoundException.java
+++ b/src/main/java/life/offonoff/ab/exception/CategoryNotFoundException.java
@@ -1,0 +1,22 @@
+package life.offonoff.ab.exception;
+
+public class CategoryNotFoundException extends NotFoundException {
+    private static final String MESSAGE = "존재하지 않는 토픽 카테고리 입니다.";
+    private static final AbCode AB_CODE = AbCode.CATEGORY_NOT_FOUND;
+    private final Long categoryId;
+
+    public CategoryNotFoundException(final Long categoryId) {
+        super(MESSAGE);
+        this.categoryId = categoryId;
+    }
+
+    @Override
+    public String getHint() {
+        return "카테고리 id ["+categoryId+"]는 존재하지 않습니다.";
+    }
+
+    @Override
+    public AbCode getAbCode() {
+        return AB_CODE;
+    }
+}

--- a/src/main/java/life/offonoff/ab/exception/LengthInvalidException.java
+++ b/src/main/java/life/offonoff/ab/exception/LengthInvalidException.java
@@ -1,0 +1,33 @@
+package life.offonoff.ab.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class LengthInvalidException extends AbException {
+    private static final String MESSAGE = "입력 길이를 확인해주세요.";
+    private static final AbCode AB_CODE = AbCode.INVALID_LENGTH_OF_FIELD;
+    private final String fieldName;
+    private final Integer minLength;
+    private final Integer maxLength;
+
+    public LengthInvalidException(String fieldName, Integer minLength, Integer maxLength) {
+        super(MESSAGE);
+        this.fieldName = fieldName;
+        this.minLength = minLength;
+        this.maxLength = maxLength;
+    }
+
+    @Override
+    public String getHint() {
+        return fieldName + "의 길이는 "+minLength+"~"+maxLength+" 사이여야 합니다.";
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+
+    @Override
+    public AbCode getAbCode() {
+        return AB_CODE;
+    }
+}

--- a/src/main/java/life/offonoff/ab/exception/NotFoundException.java
+++ b/src/main/java/life/offonoff/ab/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package life.offonoff.ab.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class NotFoundException extends AbException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatus.NOT_FOUND.value();
+    }
+}

--- a/src/main/java/life/offonoff/ab/web/common/ErrorWrapper.java
+++ b/src/main/java/life/offonoff/ab/web/common/ErrorWrapper.java
@@ -1,4 +1,6 @@
 package life.offonoff.ab.web.common;
 
-public record ErrorWrapper(ErrorContent errorContent) {
+import life.offonoff.ab.exception.AbCode;
+
+public record ErrorWrapper(AbCode abCode, ErrorContent errorContent) {
 }

--- a/src/main/java/life/offonoff/ab/web/common/GlobalExceptionHandler.java
+++ b/src/main/java/life/offonoff/ab/web/common/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package life.offonoff.ab.web.common;
 
+import life.offonoff.ab.exception.AbException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,10 +11,25 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import java.util.stream.Collectors;
 
+import static life.offonoff.ab.exception.AbCode.INVALID_FIELD;
+
 @Slf4j
 // 예외가 발생했을 때 json 형태로 반환할 때 사용하는 어노테이션
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    @ExceptionHandler(AbException.class)
+    public ResponseEntity<ErrorWrapper> handleAbException(final AbException abException) {
+        log.warn("AbException = ", abException);
+
+        final ErrorWrapper error = new ErrorWrapper(
+                abException.getAbCode(),
+                ErrorContent.of(abException.getMessage(), abException.getHint(), abException.getHttpStatusCode())
+        );
+        return ResponseEntity
+                .status(HttpStatus.valueOf(abException.getHttpStatusCode()))
+                .body(error);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorWrapper> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         log.warn("MethodArgumentNotValidException = ", e);
@@ -24,6 +40,7 @@ public class GlobalExceptionHandler {
                 .collect(Collectors.joining(", "));
         final String hint = "잘못된 요청 바디입니다.";
         final ErrorWrapper errors = new ErrorWrapper(
+                INVALID_FIELD,
                 ErrorContent.of(errorFields, hint, HttpStatus.BAD_REQUEST.value())
         );
         return ResponseEntity
@@ -37,6 +54,7 @@ public class GlobalExceptionHandler {
 
         final String hint = "잘못된 타입의 요청입니다. | 인자 이름: " + e.getName() + " 필요한 타입: " + e.getRequiredType();
         final ErrorWrapper errorWrapper = new ErrorWrapper(
+                INVALID_FIELD,
                 ErrorContent.of(hint, HttpStatus.BAD_REQUEST.value())
         );
         return ResponseEntity


### PR DESCRIPTION
## What is this PR? 🔍
Exception 처리 방법 제안

### 🛠️ Issue
- #16

## Changes 📝
- `AbCode` enum 클래스 추가
  - 투두어리와 달리 숫자로 하지 않은 이유는, 투두어리때 숫자로 하면서 숫자가 겹치기도 하고, 딱히 1000~ 2000~ 등등으로 나눠놓은 이점을 못 느꼈던 것 같아서입니다. 또 문자로 하면 가독성이 숫자일 때보다 나을 것 같아요. 1000~ 등으로 범위를 안나눠도 도메인 specific한 exception이라면 앞에 CATEGORY_, TOPIC_ 등을 붙여서 나눌 수도 있을 것 같구요.
- Base가 되는 `AbException` 과 그 외 exception 클래스들 추가 
  - AbException은 HttpStatusCode / 우리가 정의한 AbCode / 기본 메세지와 힌트를 갖게 했습니다.

### 새로운 Exception을 만들기
- `AbCode`에 enum 값을 추가한다. 
- 새로운 `AbException` 구현 클래스를 만든다.
  - 이미 있는 HttpStatusCode를 공유하는 `xxNotFoundException` 등등을 상속해서 만들거나
  - `AbException`을 바로 상속해서 만들거나

## To Reviewers 📢
- @60jong 어떻게 생각하는지 알려주세요!
