### PR TITLE
feat: 멤버 complete 전에 에러 시 payload에 memberId 포함

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -35,4 +35,6 @@ operation::auth-controller-test/sign-in_exception_wrong_password[snippets="http-
 operation::auth-controller-test/sign-in_exception_email_not_found[snippets="http-request,http-response"]
 
 ==== 회원가입 완료 전 로그인 요청
+``ILLEGAL_JOIN_STATUS`` 일 땐 ``errorContent.payload``에 멤버 ID 포함하여 응답
+
 operation::auth-controller-test/signin_before_join-completed[snippets="http-request,http-response"]

--- a/src/main/java/life/offonoff/ab/application/service/auth/AuthService.java
+++ b/src/main/java/life/offonoff/ab/application/service/auth/AuthService.java
@@ -110,7 +110,7 @@ public class AuthService {
 
         // join status
         if (!member.joinCompleted()) {
-            throw new IllegalJoinStatusException(member.getJoinStatus());
+            throw new IllegalJoinStatusException(member.getId(), member.getJoinStatus());
         }
     }
 

--- a/src/main/java/life/offonoff/ab/domain/member/Member.java
+++ b/src/main/java/life/offonoff/ab/domain/member/Member.java
@@ -61,7 +61,7 @@ public class Member extends BaseEntity {
 
     public void registerAuthInfo(AuthenticationInfo authInfo) {
         if (this.authInfo != null) {
-            throw new IllegalJoinStatusException(getJoinStatus());
+            throw new IllegalJoinStatusException(id, getJoinStatus());
         }
 
         this.authInfo = authInfo;
@@ -69,7 +69,7 @@ public class Member extends BaseEntity {
 
     public void registerPersonalInfo(PersonalInfo personalInfo) {
         if (this.personalInfo != null) {
-            throw new IllegalJoinStatusException(getJoinStatus());
+            throw new IllegalJoinStatusException(id, getJoinStatus());
         }
 
         this.personalInfo = personalInfo;
@@ -77,7 +77,7 @@ public class Member extends BaseEntity {
 
     public void agreeTerms(TermsEnabled termsEnabled) {
         if (this.termsEnabled != null) {
-            throw new IllegalJoinStatusException(getJoinStatus());
+            throw new IllegalJoinStatusException(id, getJoinStatus());
         }
 
         this.termsEnabled = termsEnabled;

--- a/src/main/java/life/offonoff/ab/exception/AbException.java
+++ b/src/main/java/life/offonoff/ab/exception/AbException.java
@@ -21,4 +21,7 @@ public abstract class AbException extends RuntimeException {
     public abstract String getHint();
     public abstract int getHttpStatusCode();
     public abstract AbCode getAbCode();
+    public Object getPayload() {
+        return null;
+    }
 }

--- a/src/main/java/life/offonoff/ab/exception/IllegalJoinStatusException.java
+++ b/src/main/java/life/offonoff/ab/exception/IllegalJoinStatusException.java
@@ -5,11 +5,18 @@ import life.offonoff.ab.domain.member.JoinStatus;
 public class IllegalJoinStatusException extends AbException {
 
     private static final String MESSAGE = "올바른 회원 등록 단계가 아닙니다.";
+    private final Long memberId;
     private final JoinStatus joinStatus;
 
-    public IllegalJoinStatusException(JoinStatus joinStatus) {
+    public IllegalJoinStatusException(Long memberId, JoinStatus joinStatus) {
         super(MESSAGE);
+        this.memberId = memberId;
         this.joinStatus = joinStatus;
+    }
+
+    @Override
+    public Object getPayload() {
+        return memberId;
     }
 
     @Override

--- a/src/main/java/life/offonoff/ab/web/common/ErrorContent.java
+++ b/src/main/java/life/offonoff/ab/web/common/ErrorContent.java
@@ -1,11 +1,19 @@
 package life.offonoff.ab.web.common;
 
-public record ErrorContent(String message, String hint, int httpCode) {
-    public static ErrorContent of(final String message, final String hint, final int httpCode) {
-        return new ErrorContent(message, hint, httpCode);
-    }
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorContent(String message, String hint, int httpCode, Object payload) {
 
     public static ErrorContent of(final String message, final int httpCode) {
-        return new ErrorContent(null, message, httpCode);
+        return new ErrorContent(null, message, httpCode, null);
+    }
+
+    public static ErrorContent of(final String message, final String hint, final int httpCode) {
+        return new ErrorContent(message, hint, httpCode, null);
+    }
+
+    public static ErrorContent of(final String message, final String hint, final int httpCode, final Object payload) {
+        return new ErrorContent(message, hint, httpCode, payload);
     }
 }

--- a/src/main/java/life/offonoff/ab/web/common/GlobalExceptionHandler.java
+++ b/src/main/java/life/offonoff/ab/web/common/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ public class GlobalExceptionHandler {
 
         final ErrorWrapper error = new ErrorWrapper(
                 abException.getAbCode(),
-                ErrorContent.of(abException.getMessage(), abException.getHint(), abException.getHttpStatusCode())
+                ErrorContent.of(abException.getMessage(), abException.getHint(), abException.getHttpStatusCode(), abException.getPayload())
         );
         return ResponseEntity
                 .status(HttpStatus.valueOf(abException.getHttpStatusCode()))

--- a/src/test/java/life/offonoff/ab/web/AuthControllerTest.java
+++ b/src/test/java/life/offonoff/ab/web/AuthControllerTest.java
@@ -1,13 +1,11 @@
 package life.offonoff.ab.web;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import life.offonoff.ab.application.service.auth.AuthService;
 import life.offonoff.ab.application.service.request.TermsRequest;
 import life.offonoff.ab.application.service.request.auth.ProfileRegisterRequest;
 import life.offonoff.ab.application.service.request.auth.SignInRequest;
 import life.offonoff.ab.application.service.request.auth.SignUpRequest;
 import life.offonoff.ab.config.WebConfig;
-import life.offonoff.ab.domain.comment.Comment;
 import life.offonoff.ab.domain.member.Gender;
 import life.offonoff.ab.domain.member.JoinStatus;
 import life.offonoff.ab.domain.member.Provider;
@@ -16,9 +14,9 @@ import life.offonoff.ab.restdocs.RestDocsTest;
 import life.offonoff.ab.util.token.JwtProvider;
 import life.offonoff.ab.web.common.aspect.auth.AuthorizedArgumentResolver;
 import life.offonoff.ab.web.response.auth.join.ProfileRegisterResponse;
+import life.offonoff.ab.web.response.auth.join.SignUpResponse;
 import life.offonoff.ab.web.response.auth.join.TermsResponse;
 import life.offonoff.ab.web.response.auth.login.SignInResponse;
-import life.offonoff.ab.web.response.auth.join.SignUpResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -30,11 +28,14 @@ import org.springframework.http.MediaType;
 import java.time.LocalDate;
 
 import static life.offonoff.ab.web.AuthControllerTest.AuthUri.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(value = AuthController.class,
         excludeFilters = {
@@ -133,7 +134,7 @@ class AuthControllerTest extends RestDocsTest {
                                                                     Gender.MALE,
                                                                     "job");
         when(authService.registerProfile(any(ProfileRegisterRequest.class)))
-                .thenThrow(new IllegalJoinStatusException(JoinStatus.COMPLETE));
+                .thenThrow(new IllegalJoinStatusException(1L, JoinStatus.COMPLETE));
 
         // then
         mvc.perform(post(BASE + SIGN_UP + PROFILE)
@@ -171,7 +172,7 @@ class AuthControllerTest extends RestDocsTest {
         TermsRequest request = new TermsRequest(memberId, true);
 
         when(authService.registerTerms(any(TermsRequest.class)))
-                .thenThrow(new IllegalJoinStatusException(JoinStatus.PERSONAL_REGISTERED));
+                .thenThrow(new IllegalJoinStatusException(1L, JoinStatus.PERSONAL_REGISTERED));
 
         // when
         mvc.perform(post(BASE + SIGN_UP + TERMS)
@@ -254,7 +255,7 @@ class AuthControllerTest extends RestDocsTest {
         SignInRequest request = new SignInRequest(email, password);
 
         when(authService.signIn(any(SignInRequest.class)))
-                .thenThrow(new IllegalJoinStatusException(JoinStatus.AUTH_REGISTERED));
+                .thenThrow(new IllegalJoinStatusException(1L, JoinStatus.AUTH_REGISTERED));
 
         // then
         mvc.perform(post(BASE + SIGN_IN)


### PR DESCRIPTION
## What is this PR? 🔍
- 클라 요청대로 회원가입 전에 exception 응답에 memberId 포함

## Changes 📝
- `ErrorContent`에 `getPayload` 함수 만들어서 필요할 때 payload에 객체들 넣어서 응답할 수 있게 만들었습니다. 
  - 응답에서 ErrorContent 필드 중에 null인건 ignore되게 했습니다.

