### PR TITLE
`HOTFIX` 토픽 조회시 memberId null 분기 / fetch join with votes 삭제

### DIFF
--- a/src/main/java/life/offonoff/ab/application/service/TopicService.java
+++ b/src/main/java/life/offonoff/ab/application/service/TopicService.java
@@ -134,12 +134,12 @@ public class TopicService {
     public Slice<TopicResponse> findAll(final Long memberId, final TopicSearchRequest request, final Pageable pageable) {
 
         Slice<Topic> topics = topicRepository.findAll(memberId, request, pageable);
-        Member member = findMemberFetchVotes(memberId);
-        /* fetch join 없이 batch_size로도 성능 해결 가능
-        Member member = findMember(memberId);
-         */
 
-        return topics.map(topic -> TopicResponse.from(topic, member));
+        if (memberId == null) {
+            return topics.map(TopicResponse::from);
+        }
+
+        return topics.map(topic -> TopicResponse.from(topic, findMember(memberId)));
     }
 
     //== Hide ==//

--- a/src/test/java/life/offonoff/ab/application/service/TopicServiceTest.java
+++ b/src/test/java/life/offonoff/ab/application/service/TopicServiceTest.java
@@ -208,7 +208,7 @@ public class TopicServiceTest {
 
         Slice<Topic> topics = new SliceImpl<>(List.of(topic), pageable, false);
 
-        when(memberRepository.findByIdFetchVotes(anyLong()))
+        when(memberRepository.findByIdAndActiveTrue(anyLong()))
                 .thenReturn(Optional.of(retriever));
         when(topicRepository.findAll(anyLong(), any(TopicSearchRequest.class), any(Pageable.class)))
                 .thenReturn(topics);
@@ -261,7 +261,7 @@ public class TopicServiceTest {
 
         Slice<Topic> topics = new SliceImpl<>(List.of(topic), pageable, false);
 
-        when(memberRepository.findByIdFetchVotes(anyLong()))
+        when(memberRepository.findByIdAndActiveTrue(anyLong()))
                 .thenReturn(Optional.of(retriever));
         when(topicRepository.findAll(anyLong(), any(TopicSearchRequest.class), any(Pageable.class)))
                 .thenReturn(topics);


### PR DESCRIPTION
## What is this PR? 🔍
- 토픽 조회시 memberId null 분기 / fetch join with votes 삭제

## Changes 📝
- `topicService`에서 투표한 토픽에 votedOption 표시를 위한 `findMember` 에 memberId null 처리
- fetch join with votes 삭제 (vote 없는 멤버 조회 불가... inner join 대신 outer join 필요)

