### PR TITLE
feat: 이미 투표한 토픽에 투표할 때 exception

### DIFF
--- a/src/docs/asciidoc/topic.adoc
+++ b/src/docs/asciidoc/topic.adoc
@@ -100,6 +100,10 @@ E2. 투표 시간을 미래 시간으로 요청
 
 operation::topic-controller-test/vote-for-topic_voted-at-future_throw-exception[snippets="http-request,http-response"]
 
+E3. 이미 투표한 토픽에 대해 투표
+
+operation::topic-controller-test/vote-for-topic_duplicate-vote_throw-exception[snippets="http-request,http-response"]
+
 ### 1.8. 투표 수정
 
 OK

--- a/src/main/java/life/offonoff/ab/exception/AbCode.java
+++ b/src/main/java/life/offonoff/ab/exception/AbCode.java
@@ -21,7 +21,8 @@ public enum AbCode {
     ILLEGAL_AUTHOR,
 
     // Vote
-    DUPLICATE_VOTE,
+    DUPLICATE_VOTE_OPTION,
+    ALREADY_VOTED,
 
     // COMMENT
     UNABLE_TO_VIEW_COMMENTS,

--- a/src/main/java/life/offonoff/ab/exception/AlreadyVotedException.java
+++ b/src/main/java/life/offonoff/ab/exception/AlreadyVotedException.java
@@ -1,0 +1,32 @@
+package life.offonoff.ab.exception;
+
+import life.offonoff.ab.domain.topic.choice.ChoiceOption;
+
+public class AlreadyVotedException extends DuplicateException {
+
+    private static final String MESSAGE = "이미 투표했습니다.";
+
+    private final Long topicId;
+    private final ChoiceOption votedOption;
+
+    public AlreadyVotedException(Long topicId, ChoiceOption votedOption) {
+        super(MESSAGE);
+        this.topicId = topicId;
+        this.votedOption = votedOption;
+    }
+
+    @Override
+    public String getHint() {
+        return "토픽[id=" + topicId + "]에 대해 투표 선택지[choiceOption=" + votedOption + "]로 이미 투표했습니다.";
+    }
+
+    @Override
+    public AbCode getAbCode() {
+        return AbCode.ALREADY_VOTED;
+    }
+
+    @Override
+    public Object getPayload() {
+        return votedOption;
+    }
+}

--- a/src/main/java/life/offonoff/ab/exception/DuplicateVoteOptionException.java
+++ b/src/main/java/life/offonoff/ab/exception/DuplicateVoteOptionException.java
@@ -2,14 +2,14 @@ package life.offonoff.ab.exception;
 
 import life.offonoff.ab.domain.topic.choice.ChoiceOption;
 
-public class DuplicateVoteException extends DuplicateException {
+public class DuplicateVoteOptionException extends DuplicateException {
 
-    private static final String MESSAGE = "중복된 투표입니다.";
+    private static final String MESSAGE = "중복된 투표 선택지입니다.";
 
     private final Long topicId;
     private final ChoiceOption votedOption;
 
-    public DuplicateVoteException(Long topicId, ChoiceOption votedOption) {
+    public DuplicateVoteOptionException(Long topicId, ChoiceOption votedOption) {
         super(MESSAGE);
         this.topicId = topicId;
         this.votedOption = votedOption;
@@ -22,6 +22,11 @@ public class DuplicateVoteException extends DuplicateException {
 
     @Override
     public AbCode getAbCode() {
-        return AbCode.DUPLICATE_VOTE;
+        return AbCode.DUPLICATE_VOTE_OPTION;
+    }
+
+    @Override
+    public Object getPayload() {
+        return votedOption;
     }
 }

--- a/src/test/java/life/offonoff/ab/application/service/TopicServiceIntegrationTest.java
+++ b/src/test/java/life/offonoff/ab/application/service/TopicServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import life.offonoff.ab.domain.topic.Topic;
 import life.offonoff.ab.domain.topic.TopicSide;
 import life.offonoff.ab.domain.topic.choice.ChoiceOption;
 import life.offonoff.ab.domain.vote.Vote;
+import life.offonoff.ab.exception.AlreadyVotedException;
 import life.offonoff.ab.exception.FutureTimeRequestException;
 import life.offonoff.ab.exception.TopicReportDuplicateException;
 import life.offonoff.ab.exception.VoteByAuthorException;
@@ -183,6 +184,22 @@ public class TopicServiceIntegrationTest {
 
         assertThatThrownBy(code)
                 .isInstanceOf(FutureTimeRequestException.class);
+    }
+
+    @Test
+    void voteForTopicByMember_duplicateVote_throwException() {
+        Member author = createMember();
+        Member voter = createMember();
+        TopicResponse response = createMembersTopic(author.getId());
+        VoteRequest request = new VoteRequest(
+                ChoiceOption.CHOICE_A, LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond());
+        topicService.voteForTopicByMember(response.topicId(), voter.getId(), request);
+
+        ThrowingCallable code = () ->
+                topicService.voteForTopicByMember(response.topicId(), voter.getId(), request);
+
+        assertThatThrownBy(code)
+                .isInstanceOf(AlreadyVotedException.class);
     }
 
     private Member createMember() {

--- a/src/test/java/life/offonoff/ab/application/service/TopicServiceTest.java
+++ b/src/test/java/life/offonoff/ab/application/service/TopicServiceTest.java
@@ -10,7 +10,7 @@ import life.offonoff.ab.domain.topic.TopicSide;
 import life.offonoff.ab.domain.topic.TopicStatus;
 import life.offonoff.ab.domain.topic.choice.ChoiceOption;
 import life.offonoff.ab.domain.vote.Vote;
-import life.offonoff.ab.exception.DuplicateVoteException;
+import life.offonoff.ab.exception.DuplicateVoteOptionException;
 import life.offonoff.ab.exception.LengthInvalidException;
 import life.offonoff.ab.repository.ChoiceRepository;
 import life.offonoff.ab.repository.keyword.KeywordRepository;
@@ -345,8 +345,6 @@ public class TopicServiceTest {
         Comment comment1 = Comment.createVotersComment(vote, "content1");
         Comment comment2 = Comment.createVotersComment(vote, "content2");
 
-        when(memberRepository.findByIdAndActiveTrue(anyLong())).thenReturn(Optional.of(voter));
-        when(topicRepository.findByIdAndActiveTrue(anyLong())).thenReturn(Optional.of(topic));
         when(voteRepository.findByVoterIdAndTopicId(any(), any())).thenReturn(Optional.of(vote));
         when(commentRepository.deleteAllByWriterIdAndTopicId(anyLong(), anyLong())).thenReturn(2);
 
@@ -386,8 +384,6 @@ public class TopicServiceTest {
         Vote vote = new Vote(ChoiceOption.CHOICE_A, LocalDateTime.now());
         vote.associate(voter, topic);
 
-        when(memberRepository.findByIdAndActiveTrue(anyLong())).thenReturn(Optional.of(voter));
-        when(topicRepository.findByIdAndActiveTrue(anyLong())).thenReturn(Optional.of(topic));
         when(voteRepository.findByVoterIdAndTopicId(any(), any())).thenReturn(Optional.of(vote));
 
         // when
@@ -396,7 +392,7 @@ public class TopicServiceTest {
                         topicId,
                         voter.getId(),
                         new VoteModifyRequest(vote.getSelectedOption(), getEpochSecond(deadline.minusHours(1))))
-        ).isInstanceOf(DuplicateVoteException.class);
+        ).isInstanceOf(DuplicateVoteOptionException.class);
 
     }
 


### PR DESCRIPTION
## What is this PR? 🔍
- 이미 투표한 토픽에 투표할 때 exception

### 🛠️ Issue
- Closes #102

## Changes 📝
- 기존에 `DuplicateVote`라는 네이밍이 이미 투표한 토픽에 투표해서 중복인지, 투표 수정 시 같은 선택지로 투표해서 중복인지 모호해서 둘 다 구체화
- `checkTopicVotable`이 vote modify시에도 사용되고 있었는데, votable이면 투표 수정이 아니라 투표를 할 수 있는지 체크하는 게 맞는 것 같아서, votable과 modifiable 판단하는 메서드 나눔
```
checkTopicVotable 
 ├──> checkMemberVotableForTopic → checkTopicVotable → 투표하기 조건 체크
 └──> checkVoteModifiable        → checkTopicVotable → 투표 다시하기 조건 체크
```


- vote, modify 메서드 전마다 check 메서드가 항상 있어야해서 전후관계가 생기므로 check 메서드를 vote, modify 메서드 내부로 이동
- 클라이언트에서 필요할 수도 있을 것 같아서 exception에 paylod에 choice option 응답

## To Reviewers 📢
- 위 Changes 내용대로 투표 다시하기 부분도 좀 수정했습니다~~
