### PR TITLE
fix: 실제로 좋아요와 싫어요를 취소했을 때에만 count 감소한다

### DIFF
--- a/src/main/java/life/offonoff/ab/domain/member/Member.java
+++ b/src/main/java/life/offonoff/ab/domain/member/Member.java
@@ -218,8 +218,10 @@ public class Member extends BaseEntity {
     }
 
     public void cancelHateIfExists(Comment comment) {
-        hatedComments.removeIf(h -> h.has(comment));
-        comment.decreaseHateCount();
+        boolean removed = hatedComments.removeIf(h -> h.has(comment));
+        if (removed) {
+            comment.decreaseHateCount();
+        }
     }
 
         //== LIKE ==//
@@ -229,8 +231,10 @@ public class Member extends BaseEntity {
     }
 
     public void cancelLikeIfExists(Comment comment) {
-        likedComments.removeIf(l -> l.has(comment));
-        comment.decreaseLikeCount();
+        boolean removed = likedComments.removeIf(l -> l.has(comment));
+        if (removed) {
+            comment.decreaseLikeCount();
+        }
     }
 
     public boolean isAuthorOf(Topic topic) {


### PR DESCRIPTION
## What is this PR? 🔍
- 지금 댓글 중에 싫어요 수가 음수인 댓글이 있습니다.
![image](https://github.com/team-offonoff/server/assets/101321313/b93400a2-db47-4677-ba30-590bb833d40a)

- 확인하고 로직 보니까 `removeIf` 인데 좋아요와 싫어요 count는 항상 decrease하고 있어서 조건문만 추가해줬습니다~
