### PR TITLE
fix: 댓글 삭제 시 멤버와 토픽이 모두 삭제되지 않게 한다

### DIFF
--- a/src/main/java/life/offonoff/ab/domain/comment/Comment.java
+++ b/src/main/java/life/offonoff/ab/domain/comment/Comment.java
@@ -20,14 +20,14 @@ public class Comment extends BaseEntity {
 
     private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member writer;
 
     @Enumerated(EnumType.STRING)
     private ChoiceOption writersVotedOption;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "topic_id")
     private Topic topic;
 

--- a/src/main/java/life/offonoff/ab/domain/topic/choice/Choice.java
+++ b/src/main/java/life/offonoff/ab/domain/topic/choice/Choice.java
@@ -16,7 +16,7 @@ public class Choice extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "topic_id")
     private Topic topic;
 

--- a/src/main/java/life/offonoff/ab/repository/comment/CommentRepository.java
+++ b/src/main/java/life/offonoff/ab/repository/comment/CommentRepository.java
@@ -2,6 +2,8 @@ package life.offonoff.ab.repository.comment;
 
 import life.offonoff.ab.domain.comment.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -11,5 +13,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
     int countAllByWriterIdAndTopicId(Long writerId, Long topicId);
 
+    @Modifying
+    @Query("delete from Comment c where c.writer.id = :writerId and c.topic.id = :topicId")
     int deleteAllByWriterIdAndTopicId(Long writerId, Long topicId);
 }

--- a/src/test/java/life/offonoff/ab/repository/comment/CommentRepositoryTest.java
+++ b/src/test/java/life/offonoff/ab/repository/comment/CommentRepositoryTest.java
@@ -56,15 +56,21 @@ public class CommentRepositoryTest {
         // given
         Member member = memberRepository.save(new Member("email", "pass", Provider.NONE));
         Topic topic = topicRepository.save(new Topic("topic", TopicSide.TOPIC_A));
-
         commentRepository.save(new Comment(member, topic, ChoiceOption.CHOICE_A, "content1"));
         commentRepository.save(new Comment(member, topic, ChoiceOption.CHOICE_A, "content2"));
 
+        Member member2 = memberRepository.save(new Member("email2", "pass", Provider.NONE));
+        commentRepository.save(new Comment(member2, topic, ChoiceOption.CHOICE_A, "content3"));
+
         // when
-        commentRepository.deleteAllByWriterIdAndTopicId(member.getId(), topic.getId());
+        int removed = commentRepository.deleteAllByWriterIdAndTopicId(member.getId(), topic.getId());
 
         // then
         assertThat(commentRepository.countAllByWriterIdAndTopicId(member.getId(), topic.getId()))
                 .isEqualTo(0);
+        assertThat(commentRepository.countAllByWriterIdAndTopicId(member2.getId(), topic.getId()))
+                .isEqualTo(1);
+        assertThat(removed).isEqualTo(2);
+        assertThat(memberRepository.count()).isEqualTo(2L);
     }
 }


### PR DESCRIPTION
## What is this PR? 🔍
- 회의 때 클라이언트 분들이 말한 댓글 삭제 시 500 에러 해결

## To Reviewers 📢
- 500 ERROR 발생하는 서버 로그를 살펴보니까 Comment만이 아닌 Topic까지 삭제하려 시도하는 걸 볼 수 있습니다.
![image](https://github.com/team-offonoff/server/assets/101321313/f65df671-a5a1-4c9a-a331-00ac51a8a3a0)
- Member와 Topic에 `CascadeType.ALL` 이 걸려있어서 Comment를 삭제했을때 Topic까지 삭제 시도하다가 다른 엔티티에서 참조하고 있어서 삭제를 실패한 것 같습니다. 실제로 테스트 코드에서 확인해보니 댓글 삭제 시도를 하면 토픽과 멤버가 삭제되었습니다.
- 그래서 Cascade를 삭제해줬습니다.
- 근데 저걸 삭제하니까 comment 자체가 삭제가 안되더라구요. `deleteAll`을 제가 docs랑 이것저것 찾아봤을 때 파라미터로 지우고 싶은 entity들 collection을 받고 지운다는데.. 지금 코드처럼 조건이 걸려있을 때 예시를 못찾았습니다. 어디 있나요??
- 그래서 그냥 `@Query` 사용해서 지워줬습니다. 다른 의견 있으시면 수정해주세요~~
   
