### PR TITLE
feat: 댓글 삭제 시 댓글 좋아요, 싫어요 삭제한다.

### DIFF
--- a/src/main/java/life/offonoff/ab/domain/comment/Comment.java
+++ b/src/main/java/life/offonoff/ab/domain/comment/Comment.java
@@ -9,6 +9,8 @@ import life.offonoff.ab.domain.vote.Vote;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,6 +31,7 @@ public class Comment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "topic_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Topic topic;
 
     private int likeCount = 0;

--- a/src/main/java/life/offonoff/ab/domain/comment/HatedComment.java
+++ b/src/main/java/life/offonoff/ab/domain/comment/HatedComment.java
@@ -3,10 +3,11 @@ package life.offonoff.ab.domain.comment;
 import jakarta.persistence.*;
 import life.offonoff.ab.domain.BaseEntity;
 import life.offonoff.ab.domain.member.Member;
-import life.offonoff.ab.domain.topic.Topic;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,10 +19,12 @@ public class HatedComment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member hater;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Comment comment;
 
     public HatedComment(Member member, Comment comment) {

--- a/src/main/java/life/offonoff/ab/domain/comment/LikedComment.java
+++ b/src/main/java/life/offonoff/ab/domain/comment/LikedComment.java
@@ -6,6 +6,8 @@ import life.offonoff.ab.domain.member.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,10 +19,12 @@ public class LikedComment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member liker;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Comment comment;
 
     public LikedComment(Member liker, Comment comment) {


### PR DESCRIPTION
feat: 토픽 삭제 시에 댓글 삭제한다.

## What is this PR? 🔍
- 댓글 삭제 이슈 해결

### 🛠️ Issue
- Closes #140

## Changes 📝
- 댓글 삭제 시에 댓글 좋아요, 싫어요도 삭제
- 토픽 삭제 시에 댓글도 삭제

## To Reviewers 📢
- 저번에 #139 에서 말하신 방법 외에도 on delete를 걸어주는 방식이 있어서 해당 방식 사용해서 해결했습니다.
  - 근데 엔티티에 `OnDelete` 옵션을 거는 건 테이블 만들 때 ddl에서 옵션이 걸리는 거라 db 접속해서 테이블 수정도 추가로 해줬습니다. 
  - 참고
    - https://stackoverflow.com/questions/7197181/jpa-unidirectional-many-to-one-and-cascading-delete
- 좋아요 있는 댓글에 삭제 요청해서 삭제되는 것까지 확인했습니다.
- 추가로 토픽 삭제할 때 댓글도 삭제가 안되고 있어서 그거까지 해줬습니다. 다른 조건들도 빠진 거 있으면 확인하고 추가합시당 ~~
