### PR TITLE
회원가입이 완료된 소셜 회원은 로그인 요청시에 `access_token` 발급

### DIFF
--- a/src/docs/asciidoc/oauth.adoc
+++ b/src/docs/asciidoc/oauth.adoc
@@ -36,3 +36,7 @@ operation::o-auth-controller-test/oauth_kakao_existing_member_by_id-token[snippe
 #### E1. 탈퇴한 회원
 
 operation::o-auth-controller-test/oauth_kakao_deactivated_member_by_id-token[snippets="http-request,http-response"]
+
+#### E2. 정보 미등록 회원
+
+operation::o-auth-controller-test/oauth_kakao_not_completety_joined_member_by_id-token[snippets="http-request,http-response"]

--- a/src/main/java/life/offonoff/ab/application/service/auth/OAuthService.java
+++ b/src/main/java/life/offonoff/ab/application/service/auth/OAuthService.java
@@ -57,6 +57,7 @@ public class OAuthService {
 
         return new OAuthSignInResponse(false,
                                         response.getMemberId(),
-                                        response.getJoinStatus());
+                                        response.getJoinStatus(),
+                                        response.getAccessToken());
     }
 }

--- a/src/main/java/life/offonoff/ab/web/response/oauth/OAuthSignInResponse.java
+++ b/src/main/java/life/offonoff/ab/web/response/oauth/OAuthSignInResponse.java
@@ -6,7 +6,10 @@ import lombok.Getter;
 @Getter
 public class OAuthSignInResponse extends OAuthResponse {
 
-    public OAuthSignInResponse(Boolean newMember, Long memberId, JoinStatus joinStatus) {
+    private String accessToken;
+
+    public OAuthSignInResponse(Boolean newMember, Long memberId, JoinStatus joinStatus, String accessToken) {
         super(newMember, memberId, joinStatus);
+        this.accessToken = accessToken;
     }
 }

--- a/src/main/java/life/offonoff/ab/web/response/oauth/OAuthSignUpResponse.java
+++ b/src/main/java/life/offonoff/ab/web/response/oauth/OAuthSignUpResponse.java
@@ -1,7 +1,9 @@
 package life.offonoff.ab.web.response.oauth;
 
 import life.offonoff.ab.domain.member.JoinStatus;
+import lombok.Getter;
 
+@Getter
 public class OAuthSignUpResponse extends OAuthResponse {
 
     public OAuthSignUpResponse(Boolean newMember, Long memberId, JoinStatus joinStatus) {


### PR DESCRIPTION
## What is this PR? 🔍
- 회원가입이 완료된 소셜 회원은 로그인 요청시에 `access_token` 발급

## Changes 📝
- `OAuthSignInResponse`에 필드만 추가했습니다!
