### PR TITLE
feat: JoinStatus 관련 exception대신 token null로 응답하거나 기존 내용대로 응답

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -9,20 +9,25 @@
 ```
 
 ### 3.1. 개인 정보 등록
-OK
+#### OK
 
 operation::auth-controller-test/signup_profile[snippets="http-request,http-response"]
-E1. 개인 정보 중복 예외
+
+#### E1. 개인 정보 중복 +++<s>예외</s>+++
+
+예외 X. 요청 무시하고 기존 내용대로 응답
 
 operation::auth-controller-test/signup_profile_exception[snippets="http-request,http-response"]
 
 ### 3.2. 약관 동의
 
-OK
+#### OK
 
 operation::auth-controller-test/enable_terms[snippets="http-request,http-response"]
 
-E1. 약관 동의 중복 예외
+#### E1. 약관 동의 중복 +++<s>예외</s>+++
+
+예외 X. 요청 무시하고 기존 내용대로 응답
 
 operation::auth-controller-test/enable_terms_exception[snippets="http-request,http-response"]
 
@@ -52,11 +57,6 @@ operation::auth-controller-test/sign-in_exception_wrong_password[snippets="http-
 E2. 이메일 오류
 
 operation::auth-controller-test/sign-in_exception_email_not_found[snippets="http-request,http-response"]
-
-E3. 회원가입 완료 전 로그인 요청
-``ILLEGAL_JOIN_STATUS`` 일 땐 ``errorContent.payload``에 멤버 ID 포함하여 응답
-
-operation::auth-controller-test/signin_before_join-completed[snippets="http-request,http-response"]
 
 ### 4.3 인증 토큰 재발급
 

--- a/src/docs/asciidoc/oauth.adoc
+++ b/src/docs/asciidoc/oauth.adoc
@@ -37,6 +37,8 @@ operation::o-auth-controller-test/oauth_kakao_existing_member_by_id-token[snippe
 
 operation::o-auth-controller-test/oauth_kakao_deactivated_member_by_id-token[snippets="http-request,http-response"]
 
-#### E2. 정보 미등록 회원
+#### E2. 정보 미등록 회원 +++<s>예외</s>+++
+
+에러X
 
 operation::o-auth-controller-test/oauth_kakao_not_completety_joined_member_by_id-token[snippets="http-request,http-response"]

--- a/src/main/java/life/offonoff/ab/application/service/auth/AuthService.java
+++ b/src/main/java/life/offonoff/ab/application/service/auth/AuthService.java
@@ -7,7 +7,6 @@ import life.offonoff.ab.application.service.request.auth.SignInRequest;
 import life.offonoff.ab.application.service.request.auth.SignUpRequest;
 import life.offonoff.ab.domain.member.Member;
 import life.offonoff.ab.exception.DuplicateEmailException;
-import life.offonoff.ab.exception.IllegalJoinStatusException;
 import life.offonoff.ab.exception.IllegalPasswordException;
 import life.offonoff.ab.exception.MemberByEmailNotFoundException;
 import life.offonoff.ab.util.password.PasswordEncoder;
@@ -15,9 +14,9 @@ import life.offonoff.ab.util.token.TokenProvider;
 import life.offonoff.ab.web.response.TokenRequest;
 import life.offonoff.ab.web.response.TokenResponse;
 import life.offonoff.ab.web.response.auth.join.JoinStatusResponse;
+import life.offonoff.ab.web.response.auth.join.JoinTermsResponse;
 import life.offonoff.ab.web.response.auth.join.ProfileRegisterResponse;
 import life.offonoff.ab.web.response.auth.join.SignUpResponse;
-import life.offonoff.ab.web.response.auth.join.JoinTermsResponse;
 import life.offonoff.ab.web.response.auth.login.SignInResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -103,6 +102,9 @@ public class AuthService {
         beforeSignIn(request);
 
         Member member = memberService.findMember(request.getEmail());
+        if (!member.joinCompleted()) {
+            return new SignInResponse(member.getId(), member.getJoinStatus());
+        }
 
         return new SignInResponse(member.getId(),
                                   member.getJoinStatus(),
@@ -122,11 +124,6 @@ public class AuthService {
         // match password
         if (!passwordEncoder.isMatch(request.getPassword(), member.getPassword())) {
             throw new IllegalPasswordException();
-        }
-
-        // join status
-        if (!member.joinCompleted()) {
-            throw new IllegalJoinStatusException(member.getId(), member.getJoinStatus());
         }
     }
 

--- a/src/main/java/life/offonoff/ab/domain/member/Member.java
+++ b/src/main/java/life/offonoff/ab/domain/member/Member.java
@@ -10,8 +10,10 @@ import life.offonoff.ab.domain.topic.Topic;
 import life.offonoff.ab.domain.topic.choice.ChoiceOption;
 import life.offonoff.ab.domain.topic.hide.HiddenTopic;
 import life.offonoff.ab.domain.vote.Vote;
-import life.offonoff.ab.exception.IllegalJoinStatusException;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,27 +76,21 @@ public class Member extends BaseEntity {
     }
 
     public void registerAuthInfo(AuthenticationInfo authInfo) {
-        if (this.authInfo != null) {
-            throw new IllegalJoinStatusException(id, getJoinStatus());
+        if (this.authInfo == null) {
+            this.authInfo = authInfo;
         }
-
-        this.authInfo = authInfo;
     }
 
     public void registerPersonalInfo(PersonalInfo personalInfo) {
-        if (this.personalInfo != null) {
-            throw new IllegalJoinStatusException(id, getJoinStatus());
+        if (this.personalInfo == null) {
+            this.personalInfo = personalInfo;
         }
-
-        this.personalInfo = personalInfo;
     }
 
     public void agreeTerms(TermsEnabled termsEnabled) {
-        if (this.termsEnabled != null) {
-            throw new IllegalJoinStatusException(id, getJoinStatus());
+        if (this.termsEnabled == null) {
+            this.termsEnabled = termsEnabled;
         }
-
-        this.termsEnabled = termsEnabled;
     }
 
     //== 연관관계 매핑 ==//

--- a/src/main/java/life/offonoff/ab/web/response/auth/login/SignInResponse.java
+++ b/src/main/java/life/offonoff/ab/web/response/auth/login/SignInResponse.java
@@ -1,7 +1,6 @@
 package life.offonoff.ab.web.response.auth.login;
 
 import life.offonoff.ab.domain.member.JoinStatus;
-import life.offonoff.ab.web.response.auth.join.JoinStatusResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,4 +12,8 @@ public class SignInResponse {
     private JoinStatus joinStatus;
     private String accessToken;
     private String refreshToken;
+
+    public SignInResponse(Long id, JoinStatus joinStatus) {
+        this(id, joinStatus, null, null);
+    }
 }

--- a/src/test/java/life/offonoff/ab/domain/member/MemberTest.java
+++ b/src/test/java/life/offonoff/ab/domain/member/MemberTest.java
@@ -1,31 +1,32 @@
 package life.offonoff.ab.domain.member;
 
-import life.offonoff.ab.exception.IllegalJoinStatusException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.time.LocalDate;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class MemberTest {
 
     @Test
-    @DisplayName("AuthInfo 중복 등록시 예외")
+    @DisplayName("AuthInfo 중복 등록시 예외X 그냥 무시")
     void register_authInfo_exception() {
         // given
         String email = "email";
         String password = "password";
         Provider provider = Provider.NONE;
         AuthenticationInfo authInfo = new AuthenticationInfo(email, password, provider);
-
-        // when
         Member member = new Member(email, password, provider);
 
+        // when
+        Executable code = () -> member.registerAuthInfo(authInfo);
+
         // then
-        assertThatThrownBy(() -> member.registerAuthInfo(authInfo))
-                .isInstanceOf(IllegalJoinStatusException.class);
+        assertDoesNotThrow(code);
     }
 
     @Test
@@ -46,18 +47,18 @@ public class MemberTest {
     }
 
     @Test
-    @DisplayName("PersonalInfo 중복 등록시 예외")
+    @DisplayName("PersonalInfo 중복 등록시 예외X 그냥 무시")
     void register_personalInfo_exception() {
         // given
         Member member = new Member("email", "password", Provider.NONE);
         PersonalInfo personalInfo = new PersonalInfo("nickname", LocalDate.now(), Gender.ETC, "job");
-
-        // when
         member.registerPersonalInfo(personalInfo);
 
+        // when
+        Executable code = () -> member.registerPersonalInfo(personalInfo);
+
         // then
-        assertThatThrownBy(() -> member.registerPersonalInfo(personalInfo))
-                .isInstanceOf(IllegalJoinStatusException.class);
+        assertDoesNotThrow(code);
     }
 
     @Test
@@ -78,7 +79,7 @@ public class MemberTest {
     }
 
     @Test
-    @DisplayName("TermsEnabled 중복 등록시 예외")
+    @DisplayName("TermsEnabled 중복 등록시 예외X 그냥 무시")
     void register_termsEnabled_exception() {
         // given
         Member member = new Member("email", "password", Provider.NONE);
@@ -86,12 +87,12 @@ public class MemberTest {
         member.registerPersonalInfo(personalInfo);
 
         TermsEnabled termsEnabled = new TermsEnabled(true);
-
-        // when
         member.agreeTerms(termsEnabled);
 
+        // when
+        Executable code = () -> member.agreeTerms(termsEnabled);
+
         // then
-        assertThatThrownBy(() -> member.agreeTerms(termsEnabled))
-                .isInstanceOf(IllegalJoinStatusException.class);
+        assertDoesNotThrow(code);
     }
 }

--- a/src/test/java/life/offonoff/ab/web/OAuthControllerTest.java
+++ b/src/test/java/life/offonoff/ab/web/OAuthControllerTest.java
@@ -5,7 +5,6 @@ import life.offonoff.ab.application.service.auth.OAuthService;
 import life.offonoff.ab.application.service.request.oauth.OAuthRequest;
 import life.offonoff.ab.config.WebConfig;
 import life.offonoff.ab.domain.member.JoinStatus;
-import life.offonoff.ab.exception.IllegalJoinStatusException;
 import life.offonoff.ab.exception.MemberDeactivatedException;
 import life.offonoff.ab.restdocs.RestDocsTest;
 import life.offonoff.ab.util.token.JwtProvider;
@@ -145,12 +144,13 @@ class OAuthControllerTest extends RestDocsTest {
         OAuthRequest request = new OAuthRequest(BY_IDTOKEN, null, null, "id_token");
 
         when(oAuthService.authorize(any()))
-                .thenThrow(new IllegalJoinStatusException(1L, AUTH_REGISTERED));
+                .thenReturn(new OAuthSignInResponse(false, 1L, AUTH_REGISTERED, null, null));
 
         mvc.perform(post(OAuthUri.BASE + OAuthUri.KAKAO + OAuthUri.AUTHORIZE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.joinStatus").value("AUTH_REGISTERED"))
                 .andDo(print());
     }
 


### PR DESCRIPTION
## What is this PR? 🔍
- 프론트 요청대로, JoinStatus 관련 exception대신 token null로 응답하거나 기존 내용대로 응답

### 🛠️ Issue
- Closes #129

## Changes 📝
- 멤버 정보 등록 과정 중 기존에 이미 등록한 필드면 그냥 무시하고 응답
- 회원가입 과정이 완료되지 않았을 땐 token 정보 null

## To Reviewers 📢
- 테스트 다 확인하긴 했는데 인증쪽이라 문제 없는지 한번 봐주세요~!
