### PR TITLE
fix: choice 응답시 content 클래스 타입 조회할 수 있도록 즉시 로딩

### DIFF
--- a/src/main/java/life/offonoff/ab/domain/topic/choice/Choice.java
+++ b/src/main/java/life/offonoff/ab/domain/topic/choice/Choice.java
@@ -23,7 +23,7 @@ public class Choice extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ChoiceOption choiceOption;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @JoinColumn(name = "choice_content_id")
     private ChoiceContent content;
 


### PR DESCRIPTION
## What is this PR? 🔍
- 토픽 조회 후 content가 null로 나오는 현상 해결

## Changes 📝
- 토픽 조회 시 content가 null로 나온다고 해서 확인해보니
![스크린샷 2024-02-08 오후 1 09 01](https://github.com/team-offonoff/server/assets/101321313/fa5fffad-94e0-4696-9db8-5e6e6ede6713)
- `instanceof` 조건을 안타고 null로 리턴되더라구요. `ChoiceContent` 엔티티가 지연로딩일때는 엔티티 클래스 그대로가 아니라 Hibernate Proxy 객체가 사용되기 때문에 `ImageTextChoiceContent`가 아닌 프록시 클래스로 조건문을 타지 않는 것으로 보입니다.
- 그래서 해결법으로는 unproxy해서 사용하는 방법도 있는데.. ([참고](https://www.baeldung.com/hibernate-proxy-to-real-entity-object))
- 어차피 Choice-ChoiceContent는 OneToOne이고, Choice를 조회하면서 ChoiceContent를 조회하지 않는 일도 거의 없을 것 같아서 그냥 Eager로 수정했습니다!
