### PR TITLE
Topic조회 조건 (`TopicSide` / `TopicStatus`) 추가한다. && Topic 조회 URI 통합한다.

### DIFF
--- a/src/docs/asciidoc/topic.adoc
+++ b/src/docs/asciidoc/topic.adoc
@@ -13,12 +13,12 @@ operation::topic-controller-test/create-topic[snippets="request-fields,http-requ
 ### 1.2. 토픽 조회
 
 [source.html]
-POST /topics/info/voting?keywordId=..&hidden=..
+POST /topics/info?keyword_id=..&hidden=..
 
 - access token 없이도 호출이 가능합니다.
 - 헤더에 토큰이 포함돼있다면 해당 멤버가 hide한 토픽은 제외합니다.
 - 모든 `Query Parameter` 는 `optional`
-- `최신순` 정렬은 `sort=createdAt,desc` 로 가능합니다. -> `/voting?keyword=##&sort=createdAt,desc`
+- `최신순` 정렬은 `sort=createdAt,desc` 로 가능합니다. -> `/info?keyword=##&sort=createdAt,desc`
 - 탈퇴한 멤버일 경우 ``author.active``가 ``false``로 프론트에서 처리 필요
 
 OK. 토큰 O / 기본 조회 (전체 키워드 & 투표 순)
@@ -32,6 +32,12 @@ operation::topic-controller-test/get-topic-slice_default_for_unauthorized_member
 OK. 토큰 O / 키워드별 조회 (투표 순)
 
 operation::topic-controller-test/get-topic-slice_filtered_by_keyword[snippets="http-request,http-response"]
+
+OK. 토큰 O / 종료된 토픽 조회 (투표 순)
+
+operation::topic-controller-test/get-topic-slice_closed[snippets="http-request,http-response"]
+
+
 
 ### 1.3. 토픽 신고
 

--- a/src/main/java/life/offonoff/ab/application/service/request/TopicSearchRequest.java
+++ b/src/main/java/life/offonoff/ab/application/service/request/TopicSearchRequest.java
@@ -1,7 +1,7 @@
 package life.offonoff.ab.application.service.request;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import life.offonoff.ab.domain.topic.TopicSide;
 import life.offonoff.ab.domain.topic.TopicStatus;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,15 +9,11 @@ import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 public class TopicSearchRequest {
 
-    private TopicStatus topicStatus;
+    private TopicStatus status;
+    private TopicSide side;
     @JsonProperty(value = "keyword_id")
     private Long keywordId;
-
-    @Builder
-    public TopicSearchRequest(TopicStatus topicStatus, Long keywordId) {
-        this.topicStatus = topicStatus;
-        this.keywordId = keywordId;
-    }
 }

--- a/src/main/java/life/offonoff/ab/application/service/vote/VotingTopicReadableService.java
+++ b/src/main/java/life/offonoff/ab/application/service/vote/VotingTopicReadableService.java
@@ -39,7 +39,7 @@ public class VotingTopicReadableService implements VotingTopicService {
         log.info("Voting Ended : {}", ended.size());
         ended.forEach(
                 topic -> {
-                    topic.endVote();
+                    topic.closeVote();
                     VotingResult result = aggregateVote(topic);
 
                     // 투표 종료 이벤트 발행

--- a/src/main/java/life/offonoff/ab/application/service/vote/votingtopic/container/VotingTopicContainerService.java
+++ b/src/main/java/life/offonoff/ab/application/service/vote/votingtopic/container/VotingTopicContainerService.java
@@ -6,7 +6,6 @@ import life.offonoff.ab.application.service.vote.criteria.VotingEndCriteria;
 import life.offonoff.ab.domain.topic.Topic;
 import life.offonoff.ab.domain.topic.TopicStatus;
 import life.offonoff.ab.domain.vote.VotingResult;
-import life.offonoff.ab.exception.TopicNotFoundException;
 import life.offonoff.ab.repository.topic.TopicRepository;
 import life.offonoff.ab.repository.topic.TopicSearchCond;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Transactional(readOnly = true)
@@ -56,7 +54,7 @@ public class VotingTopicContainerService implements VotingTopicService {
         log.info("Voting Ended : {}", ended.size());
         ended.forEach(vt -> {
             Topic topic = vt.getTopic();
-            topic.endVote();
+            topic.closeVote();
 
             VotingResult result = aggregateVote(topic);
 

--- a/src/main/java/life/offonoff/ab/domain/topic/Topic.java
+++ b/src/main/java/life/offonoff/ab/domain/topic/Topic.java
@@ -132,8 +132,8 @@ public class Topic extends BaseEntity {
         return requestTime.isBefore(deadline);
     }
 
-    public void endVote() {
-        this.status = TopicStatus.VOTING_ENDED;
+    public void closeVote() {
+        this.status = TopicStatus.CLOSED;
     }
 
     public void noticed() {

--- a/src/main/java/life/offonoff/ab/domain/topic/TopicStatus.java
+++ b/src/main/java/life/offonoff/ab/domain/topic/TopicStatus.java
@@ -1,5 +1,5 @@
 package life.offonoff.ab.domain.topic;
 
 public enum TopicStatus {
-    VOTING, VOTING_ENDED, NOTICED
+    VOTING, CLOSED, NOTICED
 }

--- a/src/main/java/life/offonoff/ab/repository/topic/TopicRepositoryImpl.java
+++ b/src/main/java/life/offonoff/ab/repository/topic/TopicRepositoryImpl.java
@@ -7,7 +7,6 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import life.offonoff.ab.application.service.request.TopicSearchRequest;
 import life.offonoff.ab.domain.topic.Topic;
-import life.offonoff.ab.domain.topic.hide.QHiddenTopic;
 import life.offonoff.ab.repository.pagination.PagingUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -32,9 +31,10 @@ public class TopicRepositoryImpl implements TopicRepositoryCustom {
 
         JPAQuery<Topic> baseQuery = queryFactory.selectFrom(topic)
                                                 .join(topic.author).fetchJoin()
-                                                .join(topic.keyword).fetchJoin()
-                                                .where(eqTopicStatus(request.getTopicStatus()),
-                                                        eqKeyword(request.getKeywordId()))
+                                                .leftJoin(topic.keyword).fetchJoin()
+                                                .where(eqTopicStatus(request.getStatus()),
+                                                        eqKeyword(request.getKeywordId()),
+                                                        eqTopicSide(request.getSide()))
                                                 .orderBy(TopicOrderBy.getOrderSpecifiers(pageable.getSort()))
                                                 .offset(pageable.getOffset())
                                                 .limit(pageable.getPageSize() + 1);

--- a/src/main/java/life/offonoff/ab/repository/topic/booleanexpression/TopicBooleanExpression.java
+++ b/src/main/java/life/offonoff/ab/repository/topic/booleanexpression/TopicBooleanExpression.java
@@ -3,6 +3,7 @@ package life.offonoff.ab.repository.topic.booleanexpression;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
+import life.offonoff.ab.domain.topic.TopicSide;
 import life.offonoff.ab.domain.topic.TopicStatus;
 import life.offonoff.ab.domain.topic.hide.HiddenTopic;
 
@@ -14,7 +15,12 @@ import static life.offonoff.ab.domain.topic.hide.QHiddenTopic.hiddenTopic;
 public class TopicBooleanExpression {
 
     public static BooleanExpression eqTopicStatus(TopicStatus topicStatus) {
-        return topicStatus != null ? topic.status.eq(topicStatus) : null;
+        TopicStatus status = TopicStatus.VOTING; // default STATUS condition
+
+        if (topicStatus != null) {
+            status = topicStatus;
+        }
+        return topic.status.eq(status);
     }
 
     public static BooleanExpression gtDeadline(LocalDateTime compareTime) {
@@ -27,6 +33,10 @@ public class TopicBooleanExpression {
 
     public static BooleanExpression eqKeyword(Long keywordId) {
         return keywordId != null ? topic.keyword.id.eq(keywordId) : null;
+    }
+
+    public static BooleanExpression eqTopicSide(TopicSide side) {
+        return side != null ? topic.side.eq(side) : null;
     }
 
     public static BooleanExpression hideFor(Long memberId) {

--- a/src/main/java/life/offonoff/ab/repository/topic/specification/TopicSpecificationFactory.java
+++ b/src/main/java/life/offonoff/ab/repository/topic/specification/TopicSpecificationFactory.java
@@ -11,8 +11,8 @@ public class TopicSpecificationFactory {
 
         if (request instanceof TopicSearchRequest searchRequest) {
 
-            if (searchRequest.getTopicStatus() != null) {
-                spec = spec.and(TopicSpecifications.status(searchRequest.getTopicStatus()));
+            if (searchRequest.getStatus() != null) {
+                spec = spec.and(TopicSpecifications.status(searchRequest.getStatus()));
             }
             if (searchRequest.getKeywordId() != null) {
                 spec = spec.and(TopicSpecifications.keyword(searchRequest.getKeywordId()));

--- a/src/main/java/life/offonoff/ab/web/TopicController.java
+++ b/src/main/java/life/offonoff/ab/web/TopicController.java
@@ -45,13 +45,12 @@ public class TopicController {
      * @param pageable   default 값은 page 0 / size 10 / sort 투표 많은 순(인기 순)
      * @return sliced(paged) Topic 리스트
      */
-    @GetMapping("/info/voting")
+    @GetMapping("/info")
     public ResponseEntity<PageResponse<TopicResponse>> getTopicInfos(
             @Authorized(nullable = true) Long memberId,
             TopicSearchRequest request,
             @PageableDefault(page = 0, size = 10, sort = "voteCount", direction = DESC) Pageable pageable
     ) {
-        request.setTopicStatus(TopicStatus.VOTING);
         return ResponseEntity.ok(PageResponse.of(topicService.findAll(memberId, request, pageable)));
     }
 

--- a/src/test/java/life/offonoff/ab/application/service/TopicServiceTest.java
+++ b/src/test/java/life/offonoff/ab/application/service/TopicServiceTest.java
@@ -205,7 +205,10 @@ public class TopicServiceTest {
         vote.associate(retriever, topic);
 
           // search params
-        TopicSearchRequest request = new TopicSearchRequest(TopicStatus.VOTING, null);
+        TopicSearchRequest request = TopicSearchRequest.builder()
+                .status(TopicStatus.VOTING)
+                .build();
+
         Pageable pageable = PageRequest.of(0, 1, Sort.Direction.DESC, "voteCount");
 
         Slice<Topic> topics = new SliceImpl<>(List.of(topic), pageable, false);
@@ -258,7 +261,10 @@ public class TopicServiceTest {
                 .build().buildTopic();
 
         // search params
-        TopicSearchRequest request = new TopicSearchRequest(TopicStatus.VOTING, null);
+        TopicSearchRequest request = TopicSearchRequest.builder()
+                .status(TopicStatus.VOTING)
+                .build();
+
         Pageable pageable = PageRequest.of(0, 1, Sort.Direction.DESC, "voteCount");
 
         Slice<Topic> topics = new SliceImpl<>(List.of(topic), pageable, false);


### PR DESCRIPTION
## What is this PR? 🔍
- Topic조회 조건 (`TopicSide` / `TopicStatus`) 추가한다.
- Topic 조회 URI 통합한다.

### 🛠️ Issue
- Closes #101 

## Changes 📝
- A_Side는 `Keyword`가 null이라 조회 쿼리에서 `left join`으로 수정했습니다.
- TopicStatus `VOTING` / `VOTING_ENDED` / `NOTICED`인데 일단 `VOTING_ENDED` -> `CLOSED`로 수정했습니다.
  - `NOTICED`는 알림 기능 개발하면서 삭제/수정 예정입니다.
- 토픽 조회 URI를 통합했습니다. (진행중 / 종료된) `/topics/info/voting` -> `/topics/info`
  - 진행/종료 구분은 query param으로 구분합니다.