### PR TITLE
fix: Request DTO 생성 중 AbException 발생한 경우 기존 형식대로 응답

### DIFF
--- a/src/main/java/life/offonoff/ab/application/service/request/TopicCreateRequest.java
+++ b/src/main/java/life/offonoff/ab/application/service/request/TopicCreateRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import life.offonoff.ab.application.service.common.TextUtils;
 import life.offonoff.ab.domain.topic.TopicSide;
 import life.offonoff.ab.exception.LengthInvalidException;
+import life.offonoff.ab.exception.NotKoreanEnglishNumberException;
 import lombok.Builder;
 
 import java.util.List;
@@ -27,10 +28,15 @@ public record TopicCreateRequest(
         if (titleLength < TOPIC_TITLE.getMinLength() || titleLength > TOPIC_TITLE.getMaxLength()) {
             throw new LengthInvalidException("토픽 제목", TOPIC_TITLE);
         }
-        if (keywordName != null) {
+
+        boolean shouldHaveKeyword = side == TopicSide.TOPIC_B;
+        if (shouldHaveKeyword) {
             int keywordLength = TextUtils.countGraphemeClusters(keywordName);
             if (keywordLength < TOPIC_KEYWORD.getMinLength() || keywordLength > TOPIC_KEYWORD.getMaxLength()) {
                 throw new LengthInvalidException("토픽 키워드", TOPIC_KEYWORD);
+            }
+            if (!TextUtils.isOnlyKoreanEnglishNumberIncluded(keywordName)) {
+                throw new NotKoreanEnglishNumberException(keywordName);
             }
         }
     }

--- a/src/main/java/life/offonoff/ab/exception/NotKoreanEnglishNumberException.java
+++ b/src/main/java/life/offonoff/ab/exception/NotKoreanEnglishNumberException.java
@@ -5,15 +5,15 @@ import org.springframework.http.HttpStatus;
 public class NotKoreanEnglishNumberException extends AbException {
     private static final String MESSAGE = "한글, 영문, 숫자만 가능해요.";
     private static final AbCode abCode = AbCode.NOT_KOREAN_ENGLISH_NUMBER;
-    private final String nickname;
-    public NotKoreanEnglishNumberException(String nickname) {
+    private final String text;
+    public NotKoreanEnglishNumberException(String text) {
         super(MESSAGE);
-        this.nickname = nickname;
+        this.text = text;
     }
 
     @Override
     public String getHint() {
-        return "필드["+nickname+"]에 한글, 영문, 숫자가 아닌 문자가 포함되어있습니다.";
+        return "필드["+ text +"]에 한글, 영문, 숫자가 아닌 문자가 포함되어있습니다.";
     }
 
     @Override

--- a/src/main/java/life/offonoff/ab/web/common/GlobalExceptionHandler.java
+++ b/src/main/java/life/offonoff/ab/web/common/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import life.offonoff.ab.exception.AbException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -61,6 +62,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(errorWrapper);
+    }
+
+    // Request DTO 생성 중 exception 발생한 경우
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    private ResponseEntity<ErrorWrapper> handleHttpMessageNotReadableException(final HttpMessageNotReadableException e) {
+        final Throwable cause = e.getCause().getCause();
+        if (cause instanceof AbException) {
+            return handleAbException((AbException) cause);
+        }
+        return handleException(e);
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## What is this PR? 🔍
- record 인스턴스 생성할 때 필드 validation을 처리하도록 했는데, 이 때 `AbException`을 throw하면 다른 exception으로 두번 감싸져서 응답이 되더라구요. 
- 그래서 `ExceptionHandler`에서 AbException으로 인해 발생한 exception(`HttpMessageNotReadableException`)일 경우 AbException으로 처리하도록 수정했습니다.
