### PR TITLE
fix: 멤버의 프로필 이미지 삭제 후 db에서 null로 업데이트

### DIFF
--- a/src/main/java/life/offonoff/ab/application/service/member/MemberService.java
+++ b/src/main/java/life/offonoff/ab/application/service/member/MemberService.java
@@ -131,6 +131,7 @@ public class MemberService {
         String originalUrl = member.getProfileImageUrl();
         if (originalUrl != null) {
             s3Service.deleteFile(originalUrl);
+            member.removeProfileImageUrl();
         }
     }
 

--- a/src/main/java/life/offonoff/ab/domain/member/Member.java
+++ b/src/main/java/life/offonoff/ab/domain/member/Member.java
@@ -267,4 +267,8 @@ public class Member extends BaseEntity {
         this.profileImageUrl = imageUrl;
         return this.profileImageUrl;
     }
+
+    public void removeProfileImageUrl() {
+        this.profileImageUrl = null;
+    }
 }


### PR DESCRIPTION
## What is this PR? 🔍
- 프로필 이미지 삭제 후 s3에선 삭제해주고 멤버의 column은 업데이트를 안했어서 수정