### PR TITLE
토픽 작성자가 토픽 댓글 조회가 가능하게 수정한다.

### DIFF
--- a/src/docs/asciidoc/comment.adoc
+++ b/src/docs/asciidoc/comment.adoc
@@ -33,6 +33,10 @@ OK - 댓글이 하나도 없는 상황
 
 operation::comment-controller-test/get_comments_of_topic_empty_comments[snippets="http-request,http-response"]
 
+OK - 토픽 작성자가 조회
+
+operation::comment-controller-test/get_comments_by_topic_author[snippets="http-request,http-response"]
+
 E1. 존재하지 않는 토픽
 
 operation::comment-controller-test/get_comments_exception_topic_not_found[snippets="http-request,http-response"]

--- a/src/main/java/life/offonoff/ab/application/service/CommentService.java
+++ b/src/main/java/life/offonoff/ab/application/service/CommentService.java
@@ -54,11 +54,11 @@ public class CommentService {
     }
 
     private void checkMemberCanViewComments(Long memberId, Long topicId) {
-        if (!topicRepository.existsByIdAndActiveTrue(topicId)) {
-            throw new TopicNotFoundException(topicId);
-        }
+        Topic topic = findTopic(topicId);
+        Member member = findMember(memberId);
 
-        if (!voteRepository.existsByVoterIdAndTopicId(memberId, topicId)) {
+        if (!topic.isWrittenBy(member) &&
+                !voteRepository.existsByVoterIdAndTopicId(memberId, topicId)) {
             throw new UnableToViewCommentsException(topicId);
         }
     }

--- a/src/test/java/life/offonoff/ab/web/CommentControllerTest.java
+++ b/src/test/java/life/offonoff/ab/web/CommentControllerTest.java
@@ -133,6 +133,22 @@ class CommentControllerTest extends RestDocsTest {
     }
 
     @Test
+    void get_comments_by_topic_author() throws Exception {
+        // give
+        Long topicId = 1L;
+
+        when(commentService.findAll(nullable(Long.class), anyLong(), any(Pageable.class)))
+                .thenReturn(PageResponse.of(2, new SliceImpl<>(createTwoCommentResponses(topicId))));
+
+        mvc.perform(get(CommentUri.BASE)
+                        .header("Authorization", "Bearer AUTHOR_ACCESS_TOKEN")
+                        .queryParam("topic-id", String.valueOf(topicId))
+                        .queryParam("page", String.valueOf(0))
+                        .queryParam("size", String.valueOf(50)))
+            .andExpect(status().isOk());
+    }
+
+    @Test
     void get_comments_of_topic_empty_comments() throws Exception {
         Long topicId = 1L;
 


### PR DESCRIPTION
## What is this PR? 🔍
- 토픽 작성자가 토픽 댓글 조회가 가능하게 수정한다.

## Changes 📝
- `checkMemberCanViewComments`에서 토픽 작성자라면 통과하도록 수정했습니다.
- 추가 테스트 케이스로 검증 완료했습니다.