### PR TITLE
토픽 투표 수가 일정 수에 도달할 때마다 작성자에게 알림 생성 && 멤버 알림 조회

### DIFF
--- a/src/docs/asciidoc/notice.adoc
+++ b/src/docs/asciidoc/notice.adoc
@@ -1,0 +1,9 @@
+== 8. 알림 API
+### 1.1. 알림 조회
+
+[source.html]
+GET /notices
+
+OK
+
+operation::notice-controller-test/get_members_notifications[snippets="http-request,http-response"]

--- a/src/main/java/life/offonoff/ab/application/event/topic/TopicEventHandler.java
+++ b/src/main/java/life/offonoff/ab/application/event/topic/TopicEventHandler.java
@@ -3,6 +3,7 @@ package life.offonoff.ab.application.event.topic;
 import life.offonoff.ab.application.notice.NoticeService;
 import life.offonoff.ab.application.service.vote.VotingTopicService;
 import life.offonoff.ab.application.service.vote.votingtopic.container.VotingTopic;
+import life.offonoff.ab.domain.topic.Topic;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -42,5 +43,18 @@ public class TopicEventHandler {
         log.info("# Topic Vote Closed / topic-id : {}, deadline : {}", event.topic().getId(), event.topic().getDeadline());
 
         noticeService.noticeVoteResult(event.result());
+    }
+
+    /**
+     * 투표 이벤트
+     */
+    @EventListener
+    public void voted(VotedEvent event) {
+        Topic topic = event.getVote()
+                           .getTopic();
+
+        if (noticeService.shouldNoticeVoteCountForTopic(topic)) {
+            noticeService.noticeVoteCountOnTopic(topic);
+        }
     }
 }

--- a/src/main/java/life/offonoff/ab/application/event/topic/VotedEvent.java
+++ b/src/main/java/life/offonoff/ab/application/event/topic/VotedEvent.java
@@ -1,0 +1,14 @@
+package life.offonoff.ab.application.event.topic;
+
+import life.offonoff.ab.domain.vote.Vote;
+import lombok.Getter;
+
+@Getter
+public class VotedEvent {
+
+    private Vote vote;
+
+    public VotedEvent(Vote vote) {
+        this.vote = vote;
+    }
+}

--- a/src/main/java/life/offonoff/ab/application/service/TopicService.java
+++ b/src/main/java/life/offonoff/ab/application/service/TopicService.java
@@ -2,6 +2,7 @@ package life.offonoff.ab.application.service;
 
 import life.offonoff.ab.application.event.report.TopicReportEvent;
 import life.offonoff.ab.application.event.topic.TopicCreateEvent;
+import life.offonoff.ab.application.event.topic.VotedEvent;
 import life.offonoff.ab.application.service.request.*;
 import life.offonoff.ab.domain.keyword.Keyword;
 import life.offonoff.ab.domain.member.Member;
@@ -187,6 +188,9 @@ public class TopicService {
         Vote vote = new Vote(choiceOption, votedAt);
         vote.associate(member, topic);
         voteRepository.save(vote);
+
+        // publish VotedEvent
+        eventPublisher.publishEvent(new VotedEvent(vote));
 
         return VoteResponse.from(getLatestCommentOfTopic(topic), TopicResponse.from(topic, member));
     }

--- a/src/main/java/life/offonoff/ab/domain/member/Member.java
+++ b/src/main/java/life/offonoff/ab/domain/member/Member.java
@@ -195,7 +195,7 @@ public class Member extends BaseEntity {
                 .anyMatch(v -> v.isFor(topic));
     }
 
-    public void readNotification(Notification notification) {
+    public void checkNotification(Notification notification) {
         notification.check();
     }
 

--- a/src/main/java/life/offonoff/ab/domain/notice/Notification.java
+++ b/src/main/java/life/offonoff/ab/domain/notice/Notification.java
@@ -6,6 +6,7 @@ import life.offonoff.ab.domain.member.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,6 +22,7 @@ public abstract class Notification extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member receiver;
 
+    @ColumnDefault("false")
     private Boolean checked = false;
 
     public Notification(Member receiver) {

--- a/src/main/java/life/offonoff/ab/domain/notice/VoteCountOnTopicNotification.java
+++ b/src/main/java/life/offonoff/ab/domain/notice/VoteCountOnTopicNotification.java
@@ -12,10 +12,21 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static life.offonoff.ab.domain.notice.NotificationType.VOTE_COUNT_ON_TOPIC_NOTIFICATION;
-// TODO:수정대상
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @DiscriminatorValue(VOTE_COUNT_ON_TOPIC_NOTIFICATION)
 public class VoteCountOnTopicNotification extends Notification {
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    private Topic topic;
+    private int totalVoteCount;
+
+    public VoteCountOnTopicNotification(Member receiver, Topic topic) {
+        super(receiver);
+
+        this.topic = topic;
+        this.totalVoteCount = topic.getVoteCount();
+    }
 }

--- a/src/main/java/life/offonoff/ab/domain/notice/VoteResultNotification.java
+++ b/src/main/java/life/offonoff/ab/domain/notice/VoteResultNotification.java
@@ -15,7 +15,7 @@ import static life.offonoff.ab.domain.notice.NotificationType.*;
 @DiscriminatorValue(VOTE_RESULT_NOTIFICATION)
 public class VoteResultNotification extends Notification {
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     private VoteResult voteResult;
 
     public VoteResultNotification(Member member, VoteResult voteResult) {

--- a/src/main/java/life/offonoff/ab/domain/topic/Topic.java
+++ b/src/main/java/life/offonoff/ab/domain/topic/Topic.java
@@ -59,7 +59,7 @@ public class Topic extends BaseEntity {
     private List<TopicReport> reports = new ArrayList<>();
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "voting_result_id")
+    @JoinColumn(name = "vote_result_id")
     private VoteResult voteResult;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/life/offonoff/ab/domain/vote/VoteResult.java
+++ b/src/main/java/life/offonoff/ab/domain/vote/VoteResult.java
@@ -14,7 +14,7 @@ public class VoteResult extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.EAGER)
     private Topic topic;
 
     private int totalVoteCount;

--- a/src/main/java/life/offonoff/ab/repository/member/MemberRepository.java
+++ b/src/main/java/life/offonoff/ab/repository/member/MemberRepository.java
@@ -10,7 +10,11 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
-    List<Member> findAllListeningVoteResultAndVotedTopicId(Long memberId);
+    @Query("select m from Member m " +
+            "  join Vote v on v.voter.id = m.id " +
+            "    and v.topic.id = :topicId " +
+            "where m.notificationEnabled.voteResult = true")
+    List<Member> findAllListeningVoteResultAndVotedTopicId(Long topicId);
 
     Optional<Member> findByIdAndActiveTrue(Long memberId);
 

--- a/src/main/java/life/offonoff/ab/repository/notice/NotificationJdbcRepository.java
+++ b/src/main/java/life/offonoff/ab/repository/notice/NotificationJdbcRepository.java
@@ -24,7 +24,7 @@ public class NotificationJdbcRepository {
 
         Timestamp curTimeStamp = Timestamp.valueOf(LocalDateTime.now());
 
-        String query = "insert into notification (member_id, notification_type, voting_result_id, created_at, updated_at)" +
+        String query = "insert into notification (member_id, notification_type, vote_result_id, created_at, updated_at)" +
                 "values (?, ?, ?, ?, ?);";
 
         jdbcTemplate.batchUpdate(query,

--- a/src/main/java/life/offonoff/ab/repository/notice/NotificationRepository.java
+++ b/src/main/java/life/offonoff/ab/repository/notice/NotificationRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
-    List<Notification> findAllByReceiverId(Long receiverId);
+    List<Notification> findAllByReceiverIdOrderByCreatedAtDesc(Long receiverId);
 }
+

--- a/src/main/java/life/offonoff/ab/web/NoticeController.java
+++ b/src/main/java/life/offonoff/ab/web/NoticeController.java
@@ -1,0 +1,25 @@
+package life.offonoff.ab.web;
+
+import life.offonoff.ab.application.notice.NoticeService;
+import life.offonoff.ab.web.common.aspect.auth.Authorized;
+import life.offonoff.ab.web.response.notice.NoticeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/notices")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping("")
+    public ResponseEntity<List<NoticeResponse>> getNotices(@Authorized Long memberId) {
+        return ResponseEntity.ok(noticeService.findAllByReceiverId(memberId));
+    }
+}

--- a/src/main/java/life/offonoff/ab/web/response/notice/DefaultNoticeResponse.java
+++ b/src/main/java/life/offonoff/ab/web/response/notice/DefaultNoticeResponse.java
@@ -1,0 +1,20 @@
+package life.offonoff.ab.web.response.notice;
+
+import life.offonoff.ab.domain.notice.DefaultNotification;
+import lombok.Getter;
+
+import static life.offonoff.ab.domain.notice.NotificationType.DEFAULT;
+
+@Getter
+public class DefaultNoticeResponse extends NoticeResponse {
+
+    private final String title;
+    private final String content;
+
+    public DefaultNoticeResponse(DefaultNotification notification) {
+        super(DEFAULT, notification.getChecked());
+
+        this.title = notification.getTitle();
+        this.content = notification.getContent();
+    }
+}

--- a/src/main/java/life/offonoff/ab/web/response/notice/NoticeResponse.java
+++ b/src/main/java/life/offonoff/ab/web/response/notice/NoticeResponse.java
@@ -1,0 +1,15 @@
+package life.offonoff.ab.web.response.notice;
+
+import lombok.Getter;
+
+@Getter
+public abstract class NoticeResponse {
+
+    private String type;
+    private Boolean checked;
+
+    public NoticeResponse(String type, Boolean checked) {
+        this.type = type;
+        this.checked = checked;
+    }
+}

--- a/src/main/java/life/offonoff/ab/web/response/notice/NoticeResponseFactory.java
+++ b/src/main/java/life/offonoff/ab/web/response/notice/NoticeResponseFactory.java
@@ -1,0 +1,25 @@
+package life.offonoff.ab.web.response.notice;
+
+import life.offonoff.ab.domain.notice.DefaultNotification;
+import life.offonoff.ab.domain.notice.Notification;
+import life.offonoff.ab.domain.notice.VoteCountOnTopicNotification;
+import life.offonoff.ab.domain.notice.VoteResultNotification;
+
+public class NoticeResponseFactory {
+
+    public static NoticeResponse createNoticeResponse(Notification notification) {
+        if (notification instanceof DefaultNotification) {
+            return new DefaultNoticeResponse((DefaultNotification) notification);
+        }
+
+        if (notification instanceof VoteResultNotification) {
+            return new VoteResultNoticeResponse((VoteResultNotification) notification);
+        }
+
+        if (notification instanceof VoteCountOnTopicNotification) {
+            return new VoteCountOnTopicNoticeResponse((VoteCountOnTopicNotification) notification);
+        }
+
+        throw new RuntimeException();
+    }
+}

--- a/src/main/java/life/offonoff/ab/web/response/notice/VoteCountOnTopicNoticeResponse.java
+++ b/src/main/java/life/offonoff/ab/web/response/notice/VoteCountOnTopicNoticeResponse.java
@@ -1,0 +1,26 @@
+package life.offonoff.ab.web.response.notice;
+
+import life.offonoff.ab.domain.notice.VoteCountOnTopicNotification;
+import life.offonoff.ab.domain.topic.Topic;
+import lombok.Getter;
+
+import static life.offonoff.ab.domain.notice.NotificationType.VOTE_COUNT_ON_TOPIC_NOTIFICATION;
+import static life.offonoff.ab.domain.notice.NotificationType.VOTE_RESULT_NOTIFICATION;
+
+@Getter
+public class VoteCountOnTopicNoticeResponse extends NoticeResponse {
+
+    private Long topicId;
+    private String topicTitle;
+    private int totalVoteCount;
+
+    public VoteCountOnTopicNoticeResponse(VoteCountOnTopicNotification notification) {
+        super(VOTE_COUNT_ON_TOPIC_NOTIFICATION, notification.getChecked());
+
+        Topic topic = notification.getTopic();
+        this.topicId = topic.getId();
+        this.topicTitle = topic.getTitle();
+
+        this.totalVoteCount = notification.getTotalVoteCount();
+    }
+}

--- a/src/main/java/life/offonoff/ab/web/response/notice/VoteCountOnTopicNoticeResponse.java
+++ b/src/main/java/life/offonoff/ab/web/response/notice/VoteCountOnTopicNoticeResponse.java
@@ -2,6 +2,7 @@ package life.offonoff.ab.web.response.notice;
 
 import life.offonoff.ab.domain.notice.VoteCountOnTopicNotification;
 import life.offonoff.ab.domain.topic.Topic;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import static life.offonoff.ab.domain.notice.NotificationType.VOTE_COUNT_ON_TOPIC_NOTIFICATION;
@@ -22,5 +23,12 @@ public class VoteCountOnTopicNoticeResponse extends NoticeResponse {
         this.topicTitle = topic.getTitle();
 
         this.totalVoteCount = notification.getTotalVoteCount();
+    }
+
+    public VoteCountOnTopicNoticeResponse(Boolean checked, Long topicId, String topicTitle, int totalVoteCount) {
+        super(VOTE_COUNT_ON_TOPIC_NOTIFICATION, checked);
+        this.topicId = topicId;
+        this.topicTitle = topicTitle;
+        this.totalVoteCount = totalVoteCount;
     }
 }

--- a/src/main/java/life/offonoff/ab/web/response/notice/VoteResultNoticeResponse.java
+++ b/src/main/java/life/offonoff/ab/web/response/notice/VoteResultNoticeResponse.java
@@ -22,4 +22,10 @@ public class VoteResultNoticeResponse extends NoticeResponse {
         this.topicId = topic.getId();
         this.topicTitle = topic.getTitle();
     }
+
+    public VoteResultNoticeResponse(Boolean checked, Long topicId, String topicTitle) {
+        super(VOTE_RESULT_NOTIFICATION, checked);
+        this.topicId = topicId;
+        this.topicTitle = topicTitle;
+    }
 }

--- a/src/main/java/life/offonoff/ab/web/response/notice/VoteResultNoticeResponse.java
+++ b/src/main/java/life/offonoff/ab/web/response/notice/VoteResultNoticeResponse.java
@@ -1,0 +1,25 @@
+package life.offonoff.ab.web.response.notice;
+
+import life.offonoff.ab.domain.notice.VoteResultNotification;
+import life.offonoff.ab.domain.topic.Topic;
+import life.offonoff.ab.domain.vote.VoteResult;
+import lombok.Getter;
+
+import static life.offonoff.ab.domain.notice.NotificationType.VOTE_RESULT_NOTIFICATION;
+
+@Getter
+public class VoteResultNoticeResponse extends NoticeResponse {
+
+    private Long topicId;
+    private String topicTitle;
+
+    public VoteResultNoticeResponse(VoteResultNotification notification) {
+        super(VOTE_RESULT_NOTIFICATION, notification.getChecked());
+
+        VoteResult voteResult = notification.getVoteResult();
+        Topic topic = voteResult.getTopic();
+
+        this.topicId = topic.getId();
+        this.topicTitle = topic.getTitle();
+    }
+}

--- a/src/test/java/life/offonoff/ab/application/notice/NoticeServiceIntegrationTest.java
+++ b/src/test/java/life/offonoff/ab/application/notice/NoticeServiceIntegrationTest.java
@@ -1,0 +1,53 @@
+package life.offonoff.ab.application.notice;
+
+import jakarta.persistence.EntityManager;
+import life.offonoff.ab.domain.TestEntityUtil;
+import life.offonoff.ab.domain.member.Member;
+import life.offonoff.ab.domain.topic.Topic;
+import life.offonoff.ab.web.response.notice.NoticeResponse;
+import life.offonoff.ab.web.response.notice.VoteCountOnTopicNoticeResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static life.offonoff.ab.application.notice.NoticeService.VOTE_COUNT_MODULO;
+import static life.offonoff.ab.domain.TestEntityUtil.createRandomMember;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+@DisplayName("NoticeService 스프링 컨테이너 통합테스트")
+public class NoticeServiceIntegrationTest {
+
+    @Autowired
+    NoticeService noticeService;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("VoteCountOnTopic 알림 생성한다.")
+    void create_VoteCountOnTopicNotification() {
+        // given
+        Member author = createRandomMember();
+        em.persist(author);
+
+        Topic topic = TestEntityUtil.TestTopic.builder()
+                .author(author)
+                .voteCount(VOTE_COUNT_MODULO)
+                .build().buildTopic();
+        em.persist(topic);
+
+        noticeService.noticeVoteCountOnTopic(topic);
+
+        // when
+        List<NoticeResponse> responses = noticeService.findAllByReceiverId(author.getId());
+
+        // then
+        assertThat(responses.get(0)).isInstanceOf(VoteCountOnTopicNoticeResponse.class);
+    }
+}

--- a/src/test/java/life/offonoff/ab/application/notice/NoticeServiceTest.java
+++ b/src/test/java/life/offonoff/ab/application/notice/NoticeServiceTest.java
@@ -1,10 +1,16 @@
 package life.offonoff.ab.application.notice;
 
 import life.offonoff.ab.domain.member.Member;
+import life.offonoff.ab.domain.notice.DefaultNotification;
+import life.offonoff.ab.domain.notice.Notification;
+import life.offonoff.ab.domain.notice.VoteCountOnTopicNotification;
+import life.offonoff.ab.domain.notice.VoteResultNotification;
 import life.offonoff.ab.domain.topic.Topic;
 import life.offonoff.ab.domain.vote.VoteResult;
 import life.offonoff.ab.repository.member.MemberRepository;
 import life.offonoff.ab.repository.notice.NotificationRepository;
+import life.offonoff.ab.web.response.notice.DefaultNoticeResponse;
+import life.offonoff.ab.web.response.notice.NoticeResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,9 +18,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static life.offonoff.ab.application.notice.NoticeService.VOTE_COUNT_MODULO;
 import static life.offonoff.ab.domain.TestEntityUtil.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -80,5 +88,39 @@ class NoticeServiceTest {
 
         // then
         assertThat(author.getNotifications().size()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("Vote Count 알림 기준에 해당하면 알림을 생성한다.")
+    void topic_voteCount_should_noticed() {
+        // given
+        Topic topic = TestTopic.builder()
+                .id(1L)
+                .voteCount(VOTE_COUNT_MODULO)
+                .build().buildTopic();
+
+        // when
+        boolean shouldNotice = noticeService.shouldNoticeVoteCountForTopic(topic);
+
+        // then
+        assertThat(shouldNotice).isTrue();
+    }
+
+    @Test
+    void find_NoticeResponses() {
+        // given
+        Member receiver = TestMember.builder()
+                .id(1L)
+                .build().buildMember();
+        DefaultNotification notification = new DefaultNotification(receiver, "title", "content");
+
+        when(notificationRepository.findAllByReceiverIdOrderByCreatedAtDesc(anyLong()))
+                .thenReturn(List.of(notification));
+
+        // when
+        List<NoticeResponse> responses = noticeService.findAllByReceiverId(receiver.getId());
+
+        // then
+        assertThat(responses.size()).isGreaterThan(0);
     }
 }

--- a/src/test/java/life/offonoff/ab/application/service/event/topic/TopicEventHandlerTest.java
+++ b/src/test/java/life/offonoff/ab/application/service/event/topic/TopicEventHandlerTest.java
@@ -2,7 +2,10 @@ package life.offonoff.ab.application.service.event.topic;
 
 import life.offonoff.ab.application.event.topic.*;
 import life.offonoff.ab.application.notice.NoticeService;
+import life.offonoff.ab.domain.member.Member;
 import life.offonoff.ab.domain.topic.Topic;
+import life.offonoff.ab.domain.topic.choice.ChoiceOption;
+import life.offonoff.ab.domain.vote.Vote;
 import life.offonoff.ab.domain.vote.VoteResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,5 +41,21 @@ class TopicEventHandlerTest {
 
         // then
         verify(noticeService).noticeVoteResult(any(VoteResult.class));
+    }
+
+    @Test
+    @DisplayName("VoteCount 알림 기준에 해당되면 알림 생성 메서드 호출한다.")
+    void noticeVoteCount_when_shouldNoticeVoteCount() {
+        // given
+        Vote vote = createVote(ChoiceOption.CHOICE_A);
+
+        when(noticeService.shouldNoticeVoteCountForTopic(any()))
+                .thenReturn(true);
+
+        // when
+        topicEventHandler.voted(new VotedEvent(vote));
+
+        // then
+        verify(noticeService).noticeVoteCountOnTopic(any());
     }
 }

--- a/src/test/java/life/offonoff/ab/repository/notice/NotificationRepositoryTest.java
+++ b/src/test/java/life/offonoff/ab/repository/notice/NotificationRepositoryTest.java
@@ -6,6 +6,9 @@ import life.offonoff.ab.domain.TestEntityUtil.TestMember;
 import life.offonoff.ab.domain.member.Member;
 import life.offonoff.ab.domain.notice.DefaultNotification;
 import life.offonoff.ab.domain.notice.Notification;
+import life.offonoff.ab.domain.notice.VoteCountOnTopicNotification;
+import life.offonoff.ab.domain.notice.VoteResultNotification;
+import life.offonoff.ab.web.response.notice.NoticeResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -13,7 +16,10 @@ import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
+import static life.offonoff.ab.domain.TestEntityUtil.createRandomMember;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
 
 @DataJpaTest
 @Import(TestJPAConfig.class)
@@ -36,7 +42,7 @@ class NotificationRepositoryTest {
         notificationRepository.save(notification);
 
         // when
-        List<Notification> notifications = notificationRepository.findAllByReceiverId(receiver.getId());
+        List<Notification> notifications = notificationRepository.findAllByReceiverIdOrderByCreatedAtDesc(receiver.getId());
 
         // then
         assertThat(notifications.size()).isGreaterThan(0);

--- a/src/test/java/life/offonoff/ab/web/NoticeControllerTest.java
+++ b/src/test/java/life/offonoff/ab/web/NoticeControllerTest.java
@@ -1,0 +1,57 @@
+package life.offonoff.ab.web;
+
+import life.offonoff.ab.application.notice.NoticeService;
+import life.offonoff.ab.config.WebConfig;
+import life.offonoff.ab.restdocs.RestDocsTest;
+import life.offonoff.ab.util.token.JwtProvider;
+import life.offonoff.ab.web.common.aspect.auth.AuthorizedArgumentResolver;
+import life.offonoff.ab.web.response.notice.NoticeResponse;
+import life.offonoff.ab.web.response.notice.VoteCountOnTopicNoticeResponse;
+import life.offonoff.ab.web.response.notice.VoteResultNoticeResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = NoticeController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtProvider.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = AuthorizedArgumentResolver.class)
+        })
+class NoticeControllerTest extends RestDocsTest {
+
+    @MockBean
+    NoticeService noticeService;
+
+    @Test
+    void get_members_notifications() throws Exception {
+        // given
+        NoticeResponse response1 = new VoteResultNoticeResponse(false, 1L, "topic1_title");
+        NoticeResponse response2 = new VoteCountOnTopicNoticeResponse(true, 2L, "topic2_title", 100);
+
+        when(noticeService.findAllByReceiverId(nullable(Long.class)))
+                .thenReturn(List.of(response1, response2));
+
+        // then
+        mvc.perform(get(NoticeUri.BASE)
+                        .header("Authorization", "Bearer Access_Token"))
+                .andExpect(status().isOk());
+    }
+
+    private static class NoticeUri {
+        public static String BASE = "/notices";
+    }
+}

--- a/src/test/java/life/offonoff/ab/web/response/notice/NoticeResponseFactoryTest.java
+++ b/src/test/java/life/offonoff/ab/web/response/notice/NoticeResponseFactoryTest.java
@@ -1,0 +1,28 @@
+package life.offonoff.ab.web.response.notice;
+
+import life.offonoff.ab.domain.member.Member;
+import life.offonoff.ab.domain.notice.VoteCountOnTopicNotification;
+import life.offonoff.ab.domain.topic.Topic;
+import org.junit.jupiter.api.Test;
+
+import static life.offonoff.ab.domain.TestEntityUtil.createRandomMember;
+import static life.offonoff.ab.domain.TestEntityUtil.createRandomTopic;
+import static org.assertj.core.api.Assertions.*;
+
+class NoticeResponseFactoryTest {
+
+    @Test
+    void create_NoticeResponse() {
+        // given
+        Topic topic = createRandomTopic();
+        Member member = createRandomMember();
+
+        VoteCountOnTopicNotification notification = new VoteCountOnTopicNotification(member, topic);
+
+        // when
+        NoticeResponse noticeResponse = NoticeResponseFactory.createNoticeResponse(notification);
+
+        // then
+        assertThat(noticeResponse).isInstanceOf(VoteCountOnTopicNoticeResponse.class);
+    }
+}


### PR DESCRIPTION
## What is this PR? 🔍
- 토픽 투표 수가 일정 수에 도달할 때마다 작성자에게 알림 생성
- 멤버의 알림 조회

## Changes 📝
- 투표가 생성될 때 마다 `VotedEvent`가 발행되게 했고, 그때마다 `noticeService.shouldNoticeVoteCountForTopic`로 투표 수에 대한 알림 발송 여부를 체크했습니다.

- 알림 응답 DTO를 `NoticeResponse`로 추상화했습니다.

## To Reviewers
- 알림 체크 기록하는 API 개발 예정
- 좋아요 알림 개발 예정
- 댓글 알림 개발 예정