### PR TITLE
fix: 토픽 선택지에 text가 null일때는 길이 검사 안한다

### DIFF
--- a/src/main/java/life/offonoff/ab/application/service/request/ImageTextChoiceContentCreateRequest.java
+++ b/src/main/java/life/offonoff/ab/application/service/request/ImageTextChoiceContentCreateRequest.java
@@ -20,9 +20,12 @@ public record ImageTextChoiceContentCreateRequest(
     }
 
     public ImageTextChoiceContentCreateRequest {
-        int length = TextUtils.countGraphemeClusters(text);
-        if (length < TOPIC_CHOICE_TEXT.getMinLength() || length > TOPIC_CHOICE_TEXT.getMaxLength()) {
-            throw new LengthInvalidException("토픽 선택지 텍스트", TOPIC_CHOICE_TEXT);
+        boolean shouldHaveTextContent = (imageUrl == null) || (imageUrl.isEmpty());
+        if (shouldHaveTextContent) {
+            int length = TextUtils.countGraphemeClusters(text);
+            if (length < TOPIC_CHOICE_TEXT.getMinLength() || length > TOPIC_CHOICE_TEXT.getMaxLength()) {
+                throw new LengthInvalidException("토픽 선택지 텍스트", TOPIC_CHOICE_TEXT);
+            }
         }
     }
 }


### PR DESCRIPTION
## What is this PR? 🔍
- 토픽 선택지 request에서, text가 항상 길이 조건을 만족하도록 구현해놨었습니다.
- 근데 이미지 url만 있을 때도 있다보니, 이미지만 있는 선택지에서 exception 발생하여 이미지 url이 null이거나 비어있을 때만 text를 검사하도록 수정했습니다.
