### PR TITLE
feat: Notification 생성 시 새로 `save`하는 경우 트랜잭션 분리한다

### DIFF
--- a/src/main/java/life/offonoff/ab/application/notification/NotificationService.java
+++ b/src/main/java/life/offonoff/ab/application/notification/NotificationService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -45,7 +46,11 @@ public class NotificationService {
     }
 
     //== notify ==//
-    @Transactional
+
+    /**
+     * Notification 생성 트랜잭션 분리하기 위해 새로운 트랜잭션에서 실행됨
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void notifyVoteResult(Topic topic) {
         // voters' notifications
         List<Member> voters = memberRepository.findAllListeningVoteResultAndVotedTopicId(topic.getId());
@@ -76,7 +81,10 @@ public class NotificationService {
         }
     }
 
-    @Transactional
+    /**
+     * Notification 생성 트랜잭션 분리하기 위해 새로운 트랜잭션에서 실행됨
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void notifyLikeInComment(LikedComment likedComment) {
         if (shouldNotifyLikeInComment(likedComment)) {
             LikeInCommentNotification notification = new LikeInCommentNotification(likedComment.getComment());
@@ -97,7 +105,10 @@ public class NotificationService {
         return !likerIsWriter && writerListenLikeInComment;
     }
 
-    @Transactional
+    /**
+     * Notification 생성 트랜잭션 분리하기 위해 새로운 트랜잭션에서 실행됨
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void notifyCommentOnTopic(Comment comment) {
         if (shouldNotifyCommentOnTopic(comment)) {
             CommentOnTopicNotification notification = new CommentOnTopicNotification(comment);
@@ -117,7 +128,10 @@ public class NotificationService {
         return commenterIsNotAuthor && authorListenCommentOnTopic;
     }
 
-    @Transactional
+    /**
+     * Notification 생성 트랜잭션 분리하기 위해 새로운 트랜잭션에서 실행됨
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void notifyVoteCountOnTopic(Topic topic) {
         if (shouldNotifyVoteCountForTopic(topic)) {
             VoteCountOnTopicNotification notification = new VoteCountOnTopicNotification(topic);

--- a/src/main/java/life/offonoff/ab/application/notification/NotificationService.java
+++ b/src/main/java/life/offonoff/ab/application/notification/NotificationService.java
@@ -81,10 +81,7 @@ public class NotificationService {
         }
     }
 
-    /**
-     * Notification 생성 트랜잭션 분리하기 위해 새로운 트랜잭션에서 실행됨
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void notifyLikeInComment(LikedComment likedComment) {
         if (shouldNotifyLikeInComment(likedComment)) {
             LikeInCommentNotification notification = new LikeInCommentNotification(likedComment.getComment());
@@ -105,10 +102,7 @@ public class NotificationService {
         return !likerIsWriter && writerListenLikeInComment;
     }
 
-    /**
-     * Notification 생성 트랜잭션 분리하기 위해 새로운 트랜잭션에서 실행됨
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void notifyCommentOnTopic(Comment comment) {
         if (shouldNotifyCommentOnTopic(comment)) {
             CommentOnTopicNotification notification = new CommentOnTopicNotification(comment);
@@ -128,10 +122,7 @@ public class NotificationService {
         return commenterIsNotAuthor && authorListenCommentOnTopic;
     }
 
-    /**
-     * Notification 생성 트랜잭션 분리하기 위해 새로운 트랜잭션에서 실행됨
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void notifyVoteCountOnTopic(Topic topic) {
         if (shouldNotifyVoteCountForTopic(topic)) {
             VoteCountOnTopicNotification notification = new VoteCountOnTopicNotification(topic);

--- a/src/test/java/life/offonoff/ab/application/service/CommentServiceTest.java
+++ b/src/test/java/life/offonoff/ab/application/service/CommentServiceTest.java
@@ -1,6 +1,7 @@
 package life.offonoff.ab.application.service;
 
 import jakarta.persistence.EntityManager;
+import life.offonoff.ab.application.notification.NotificationService;
 import life.offonoff.ab.application.service.common.LengthInfo;
 import life.offonoff.ab.application.service.request.CommentRequest;
 import life.offonoff.ab.domain.TestEntityUtil;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,6 +53,9 @@ class CommentServiceTest {
 
     @Mock
     MemberRepository memberRepository;
+
+    @MockBean
+    NotificationService notificationService;
 
     Member topicAuthor;
     Member voter;

--- a/src/test/java/life/offonoff/ab/application/service/vote/VotingTopicContainerServiceIntegrationTest.java
+++ b/src/test/java/life/offonoff/ab/application/service/vote/VotingTopicContainerServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -25,6 +26,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@Transactional
 @SpringBootTest
 @Import(TestVoteConfig.TestContainerVotingTopicConfig.class)
 public class VotingTopicContainerServiceIntegrationTest {


### PR DESCRIPTION
## What is this PR? 🔍
- Notification 생성 시 데드락이 발생할 수 있는 여지가 있습니다.
  - topic의 status, 투표수, 좋아요수를 수정하고 event를 publish하면 notification이 생성되는데, 이 때 모두 db 차원에서는 같은 트랜잭션에서 실행됩니다.
  - 이로 인해 notification 생성시 topic에 대한 S락을 갖고 있는 상태에서 notification insert 후에 나중에 topic에 대한 X락을 서로 얻으려고 하면서 문제가 발생할 여지가 있습니다.
- 그래서 새로운 트랜잭션으로 분리했습니다.
  - 다른 방법도 있긴 한데 제 생각엔 이 방법이 가장 나은 것 같아서 이렇게 수정했습니다. [블로그 글](https://melonturtle.netlify.app/mysql-concurrency-foreign-key/)에 더 자세한 내용은 적어놨습니다. 다른 더 좋은 방법 있으시면 알려주세요!
- 테스트는 따로 작성하지 않았고 실행해서 트랜잭션이 잘 분리되고 락이 해제되는 걸 확인했습니다. 

### 🛠️ Issue
- Closes #192

